### PR TITLE
Rename several metrics to standardize naming conventions

### DIFF
--- a/cmd/gpfs_mmdf_exporter/main_test.go
+++ b/cmd/gpfs_mmdf_exporter/main_test.go
@@ -61,24 +61,18 @@ mmdf:fsTotal:0:1:::3661677723648:481202021888:14:12117655064:0:
 mmdf:inode:0:1:::430741822:484301506:915043328:1332164000:
 `
 	expected := `
+# HELP gpfs_fs_allocated_inodes GPFS filesystem inodes allocated
+# TYPE gpfs_fs_allocated_inodes gauge
+gpfs_fs_allocated_inodes{fs="project"} 9.15043328e+08
 # HELP gpfs_fs_free_bytes GPFS filesystem free size in bytes
 # TYPE gpfs_fs_free_bytes gauge
 gpfs_fs_free_bytes{fs="project"} 4.92750870413312e+14
+# HELP gpfs_fs_free_inodes GPFS filesystem inodes free
+# TYPE gpfs_fs_free_inodes gauge
+gpfs_fs_free_inodes{fs="project"} 4.84301506e+08
 # HELP gpfs_fs_free_percent GPFS filesystem free percent
 # TYPE gpfs_fs_free_percent gauge
 gpfs_fs_free_percent{fs="project"} 14
-# HELP gpfs_fs_inodes_allocated GPFS filesystem inodes allocated
-# TYPE gpfs_fs_inodes_allocated gauge
-gpfs_fs_inodes_allocated{fs="project"} 9.15043328e+08
-# HELP gpfs_fs_inodes_free GPFS filesystem inodes free
-# TYPE gpfs_fs_inodes_free gauge
-gpfs_fs_inodes_free{fs="project"} 4.84301506e+08
-# HELP gpfs_fs_inodes_total GPFS filesystem inodes total
-# TYPE gpfs_fs_inodes_total gauge
-gpfs_fs_inodes_total{fs="project"} 1.332164e+09
-# HELP gpfs_fs_inodes_used GPFS filesystem inodes used
-# TYPE gpfs_fs_inodes_used gauge
-gpfs_fs_inodes_used{fs="project"} 4.30741822e+08
 # HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 # TYPE gpfs_fs_metadata_free_bytes gauge
 gpfs_fs_metadata_free_bytes{fs="project"} 6.155570511872e+12
@@ -90,7 +84,13 @@ gpfs_fs_metadata_free_percent{fs="project"} 43
 gpfs_fs_metadata_total_bytes{fs="project"} 1.4224931684352e+13
 # HELP gpfs_fs_total_bytes GPFS filesystem total size in bytes
 # TYPE gpfs_fs_total_bytes gauge
-gpfs_fs_total_bytes{fs="project"} 3.749557989015552e+15`
+gpfs_fs_total_bytes{fs="project"} 3.749557989015552e+15
+# HELP gpfs_fs_total_inodes GPFS filesystem inodes total
+# TYPE gpfs_fs_total_inodes gauge
+gpfs_fs_total_inodes{fs="project"} 1.332164e+09
+# HELP gpfs_fs_used_inodes GPFS filesystem inodes used
+# TYPE gpfs_fs_used_inodes gauge
+gpfs_fs_used_inodes{fs="project"} 4.30741822e+08`
 	collectors.MmdfExec = func(fs string, ctx context.Context) (string, error) {
 		return mmdfStdout, nil
 	}

--- a/collectors/mmdf.go
+++ b/collectors/mmdf.go
@@ -83,13 +83,13 @@ func init() {
 
 func NewMmdfCollector(logger log.Logger) Collector {
 	return &MmdfCollector{
-		InodesUsed: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "inodes_used"),
+		InodesUsed: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "used_inodes"),
 			"GPFS filesystem inodes used", []string{"fs"}, nil),
-		InodesFree: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "inodes_free"),
+		InodesFree: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "free_inodes"),
 			"GPFS filesystem inodes free", []string{"fs"}, nil),
-		InodesAllocated: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "inodes_allocated"),
+		InodesAllocated: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "allocated_inodes"),
 			"GPFS filesystem inodes allocated", []string{"fs"}, nil),
-		InodesTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "inodes_total"),
+		InodesTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "total_inodes"),
 			"GPFS filesystem inodes total", []string{"fs"}, nil),
 		FSTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "total_bytes"),
 			"GPFS filesystem total size in bytes", []string{"fs"}, nil),

--- a/collectors/mmdf_test.go
+++ b/collectors/mmdf_test.go
@@ -121,24 +121,18 @@ func TestMmdfCollector(t *testing.T) {
 		return mmdfStdout, nil
 	}
 	expected := `
+		# HELP gpfs_fs_allocated_inodes GPFS filesystem inodes allocated
+		# TYPE gpfs_fs_allocated_inodes gauge
+		gpfs_fs_allocated_inodes{fs="project"} 915043328
 		# HELP gpfs_fs_free_bytes GPFS filesystem free size in bytes
 		# TYPE gpfs_fs_free_bytes gauge
 		gpfs_fs_free_bytes{fs="project"} 492750870413312
+		# HELP gpfs_fs_free_inodes GPFS filesystem inodes free
+		# TYPE gpfs_fs_free_inodes gauge
+		gpfs_fs_free_inodes{fs="project"} 484301506
 		# HELP gpfs_fs_free_percent GPFS filesystem free percent
 		# TYPE gpfs_fs_free_percent gauge
 		gpfs_fs_free_percent{fs="project"} 14
-		# HELP gpfs_fs_inodes_allocated GPFS filesystem inodes allocated
-		# TYPE gpfs_fs_inodes_allocated gauge
-		gpfs_fs_inodes_allocated{fs="project"} 915043328
-		# HELP gpfs_fs_inodes_free GPFS filesystem inodes free
-		# TYPE gpfs_fs_inodes_free gauge
-		gpfs_fs_inodes_free{fs="project"} 484301506
-		# HELP gpfs_fs_inodes_total GPFS filesystem inodes total
-		# TYPE gpfs_fs_inodes_total gauge
-		gpfs_fs_inodes_total{fs="project"} 1332164000
-		# HELP gpfs_fs_inodes_used GPFS filesystem inodes used
-		# TYPE gpfs_fs_inodes_used gauge
-		gpfs_fs_inodes_used{fs="project"} 430741822
 		# HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 		# TYPE gpfs_fs_metadata_free_bytes gauge
 		gpfs_fs_metadata_free_bytes{fs="project"} 6155570511872
@@ -151,6 +145,12 @@ func TestMmdfCollector(t *testing.T) {
 		# HELP gpfs_fs_total_bytes GPFS filesystem total size in bytes
 		# TYPE gpfs_fs_total_bytes gauge
 		gpfs_fs_total_bytes{fs="project"} 3749557989015552
+		# HELP gpfs_fs_total_inodes GPFS filesystem inodes total
+		# TYPE gpfs_fs_total_inodes gauge
+		gpfs_fs_total_inodes{fs="project"} 1332164000
+		# HELP gpfs_fs_used_inodes GPFS filesystem inodes used
+		# TYPE gpfs_fs_used_inodes gauge
+		gpfs_fs_used_inodes{fs="project"} 430741822
 	`
 	collector := NewMmdfCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -160,7 +160,7 @@ func TestMmdfCollector(t *testing.T) {
 		t.Errorf("Unexpected collection count %d, expected 14", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
-		"gpfs_fs_inodes_used", "gpfs_fs_inodes_free", "gpfs_fs_inodes_allocated", "gpfs_fs_inodes_total",
+		"gpfs_fs_used_inodes", "gpfs_fs_free_inodes", "gpfs_fs_allocated_inodes", "gpfs_fs_total_inodes",
 		"gpfs_fs_free_bytes", "gpfs_fs_free_percent", "gpfs_fs_total_bytes",
 		"gpfs_fs_metadata_total_bytes", "gpfs_fs_metadata_free_bytes", "gpfs_fs_metadata_free_percent"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
@@ -190,18 +190,18 @@ mmlsfs::0:1:::project:defaultMountPoint:%2Ffs%2Fproject::
 		# HELP gpfs_fs_free_percent GPFS filesystem free percent
 		# TYPE gpfs_fs_free_percent gauge
 		gpfs_fs_free_percent{fs="project"} 14
-		# HELP gpfs_fs_inodes_allocated GPFS filesystem inodes allocated
-		# TYPE gpfs_fs_inodes_allocated gauge
-		gpfs_fs_inodes_allocated{fs="project"} 915043328
-		# HELP gpfs_fs_inodes_free GPFS filesystem inodes free
-		# TYPE gpfs_fs_inodes_free gauge
-		gpfs_fs_inodes_free{fs="project"} 484301506
-		# HELP gpfs_fs_inodes_total GPFS filesystem inodes total
-		# TYPE gpfs_fs_inodes_total gauge
-		gpfs_fs_inodes_total{fs="project"} 1332164000
-		# HELP gpfs_fs_inodes_used GPFS filesystem inodes used
-		# TYPE gpfs_fs_inodes_used gauge
-		gpfs_fs_inodes_used{fs="project"} 430741822
+		# HELP gpfs_fs_allocated_inodes GPFS filesystem inodes allocated
+		# TYPE gpfs_fs_allocated_inodes gauge
+		gpfs_fs_allocated_inodes{fs="project"} 915043328
+		# HELP gpfs_fs_free_inodes GPFS filesystem inodes free
+		# TYPE gpfs_fs_free_inodes gauge
+		gpfs_fs_free_inodes{fs="project"} 484301506
+		# HELP gpfs_fs_total_inodes GPFS filesystem inodes total
+		# TYPE gpfs_fs_total_inodes gauge
+		gpfs_fs_total_inodes{fs="project"} 1332164000
+		# HELP gpfs_fs_used_inodes GPFS filesystem inodes used
+		# TYPE gpfs_fs_used_inodes gauge
+		gpfs_fs_used_inodes{fs="project"} 430741822
 		# HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 		# TYPE gpfs_fs_metadata_free_bytes gauge
 		gpfs_fs_metadata_free_bytes{fs="project"} 6155570511872
@@ -223,7 +223,7 @@ mmlsfs::0:1:::project:defaultMountPoint:%2Ffs%2Fproject::
 		t.Errorf("Unexpected collection count %d, expected 16", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
-		"gpfs_fs_inodes_used", "gpfs_fs_inodes_free", "gpfs_fs_inodes_allocated", "gpfs_fs_inodes_total",
+		"gpfs_fs_used_inodes", "gpfs_fs_free_inodes", "gpfs_fs_allocated_inodes", "gpfs_fs_total_inodes",
 		"gpfs_fs_free_bytes", "gpfs_fs_free_percent", "gpfs_fs_total_bytes",
 		"gpfs_fs_metadata_total_bytes", "gpfs_fs_metadata_free_bytes", "gpfs_fs_metadata_free_percent"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)

--- a/collectors/mmpmon.go
+++ b/collectors/mmpmon.go
@@ -71,11 +71,11 @@ func init() {
 
 func NewMmpmonCollector(logger log.Logger) Collector {
 	return &MmpmonCollector{
-		read_bytes: prometheus.NewDesc(prometheus.BuildFQName(namespace, "perf", "read_bytes"),
+		read_bytes: prometheus.NewDesc(prometheus.BuildFQName(namespace, "perf", "read_bytes_total"),
 			"GPFS read bytes", []string{"fs", "nodename"}, nil),
-		write_bytes: prometheus.NewDesc(prometheus.BuildFQName(namespace, "perf", "write_bytes"),
+		write_bytes: prometheus.NewDesc(prometheus.BuildFQName(namespace, "perf", "write_bytes_total"),
 			"GPFS write bytes", []string{"fs", "nodename"}, nil),
-		operations: prometheus.NewDesc(prometheus.BuildFQName(namespace, "perf", "operations"),
+		operations: prometheus.NewDesc(prometheus.BuildFQName(namespace, "perf", "operations_total"),
 			"GPFS operationgs reported by mmpmon", []string{"fs", "nodename", "operation"}, nil),
 		logger: logger,
 	}

--- a/collectors/mmpmon_test.go
+++ b/collectors/mmpmon_test.go
@@ -112,28 +112,28 @@ func TestMmpmonCollector(t *testing.T) {
 		return mmpmonStdout, nil
 	}
 	expected := `
-		# HELP gpfs_perf_operations GPFS operationgs reported by mmpmon
-		# TYPE gpfs_perf_operations counter
-		gpfs_perf_operations{fs="project",nodename="ib-pitzer-rw02.ten",operation="closes"} 513
-		gpfs_perf_operations{fs="project",nodename="ib-pitzer-rw02.ten",operation="inode_updates"} 169
-		gpfs_perf_operations{fs="project",nodename="ib-pitzer-rw02.ten",operation="opens"} 513
-		gpfs_perf_operations{fs="project",nodename="ib-pitzer-rw02.ten",operation="read_dir"} 0
-		gpfs_perf_operations{fs="project",nodename="ib-pitzer-rw02.ten",operation="reads"} 0
-		gpfs_perf_operations{fs="project",nodename="ib-pitzer-rw02.ten",operation="writes"} 0
-		gpfs_perf_operations{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="closes"} 2201576
-		gpfs_perf_operations{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="inode_updates"} 544768
-		gpfs_perf_operations{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="opens"} 2377656
-		gpfs_perf_operations{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="read_dir"} 40971
-		gpfs_perf_operations{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="reads"} 59420404
-		gpfs_perf_operations{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="writes"} 18874626
-		# HELP gpfs_perf_read_bytes GPFS read bytes
-		# TYPE gpfs_perf_read_bytes counter
-		gpfs_perf_read_bytes{fs="project",nodename="ib-pitzer-rw02.ten"} 0
-		gpfs_perf_read_bytes{fs="scratch",nodename="ib-pitzer-rw02.ten"} 2.05607400434e+11
-		# HELP gpfs_perf_write_bytes GPFS write bytes
-		# TYPE gpfs_perf_write_bytes counter
-		gpfs_perf_write_bytes{fs="project",nodename="ib-pitzer-rw02.ten"} 0
-		gpfs_perf_write_bytes{fs="scratch",nodename="ib-pitzer-rw02.ten"} 74839282351
+		# HELP gpfs_perf_operations_total GPFS operationgs reported by mmpmon
+		# TYPE gpfs_perf_operations_total counter
+		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="closes"} 513
+		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="inode_updates"} 169
+		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="opens"} 513
+		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="read_dir"} 0
+		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="reads"} 0
+		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="writes"} 0
+		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="closes"} 2201576
+		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="inode_updates"} 544768
+		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="opens"} 2377656
+		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="read_dir"} 40971
+		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="reads"} 59420404
+		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="writes"} 18874626
+		# HELP gpfs_perf_read_bytes_total GPFS read bytes
+		# TYPE gpfs_perf_read_bytes_total counter
+		gpfs_perf_read_bytes_total{fs="project",nodename="ib-pitzer-rw02.ten"} 0
+		gpfs_perf_read_bytes_total{fs="scratch",nodename="ib-pitzer-rw02.ten"} 2.05607400434e+11
+		# HELP gpfs_perf_write_bytes_total GPFS write bytes
+		# TYPE gpfs_perf_write_bytes_total counter
+		gpfs_perf_write_bytes_total{fs="project",nodename="ib-pitzer-rw02.ten"} 0
+		gpfs_perf_write_bytes_total{fs="scratch",nodename="ib-pitzer-rw02.ten"} 74839282351
 	`
 	collector := NewMmpmonCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -142,7 +142,8 @@ func TestMmpmonCollector(t *testing.T) {
 	} else if val != 19 {
 		t.Errorf("Unexpected collection count %d, expected 19", val)
 	}
-	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected), "gpfs_perf_read_bytes", "gpfs_perf_write_bytes", "gpfs_perf_operations"); err != nil {
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
+		"gpfs_perf_read_bytes_total", "gpfs_perf_write_bytes_total", "gpfs_perf_operations_total"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }


### PR DESCRIPTION
* gpfs_perf_read_bytes to gpfs_perf_read_bytes_total
* gpfs_perf_write_bytes to gpfs_perf_write_bytes_total
* gpfs_perf_operations to gpfs_perf_operations_total
* gpfs_fs_inodes_allocated to gpfs_fs_allocated_inodes
* gpfs_fs_inodes_free to gpfs_fs_free_inodes
* gpfs_fs_inodes_total to gpfs_fs_total_inodes
* gpfs_fs_inodes_used to gpfs_fs_used_inodes