### PR TITLE
Better metric naming and values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 ** gpfs_fs_inodes_free to gpfs_fs_free_inodes
 ** gpfs_fs_inodes_total to gpfs_fs_total_inodes
 ** gpfs_fs_inodes_used to gpfs_fs_used_inodes
+** gpfs_fs_total_inodes to gpfs_fs_inodes
+** gpfs_fs_total_bytes to gpfs_fs_size_bytes
+** gpfs_fs_metadata_total_bytes to gpfs_fs_metadata_size_bytes
+* Change gpfs_fs_metadata_free_percent and gpfs_fs_free_percent metrics to ratio of 0.0-1.0
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 ** gpfs_fs_total_inodes to gpfs_fs_inodes
 ** gpfs_fs_total_bytes to gpfs_fs_size_bytes
 ** gpfs_fs_metadata_total_bytes to gpfs_fs_metadata_size_bytes
-* Change gpfs_fs_metadata_free_percent and gpfs_fs_free_percent metrics to ratio of 0.0-1.0
+* Removed metrics that can be calculated using other metrics
+** gpfs_fs_metadata_free_percent
+** gpfs_fs_free_percent metrics
 * Remove nodename label from gpfs_perf_* metrics, replace with gpfs_perf_info metric
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ** gpfs_fs_total_bytes to gpfs_fs_size_bytes
 ** gpfs_fs_metadata_total_bytes to gpfs_fs_metadata_size_bytes
 * Change gpfs_fs_metadata_free_percent and gpfs_fs_free_percent metrics to ratio of 0.0-1.0
+* Remove nodename label from gpfs_perf_* metrics, replace with gpfs_perf_info metric
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ** gpfs_fs_metadata_free_percent
 ** gpfs_fs_free_percent metrics
 * Remove nodename label from gpfs_perf_* metrics, replace with gpfs_perf_info metric
+* mmces and mmhealth status metrics will always have value 1, only the `status` label will change
 
 ### Improvements
 

--- a/cmd/gpfs_mmdf_exporter/main_test.go
+++ b/cmd/gpfs_mmdf_exporter/main_test.go
@@ -70,18 +70,12 @@ gpfs_fs_free_bytes{fs="project"} 4.92750870413312e+14
 # HELP gpfs_fs_free_inodes GPFS filesystem inodes free
 # TYPE gpfs_fs_free_inodes gauge
 gpfs_fs_free_inodes{fs="project"} 4.84301506e+08
-# HELP gpfs_fs_free_percent GPFS filesystem free percent (ratio 0.0-1.0)
-# TYPE gpfs_fs_free_percent gauge
-gpfs_fs_free_percent{fs="project"} 0.14
 # HELP gpfs_fs_inodes GPFS filesystem inodes total
 # TYPE gpfs_fs_inodes gauge
 gpfs_fs_inodes{fs="project"} 1.332164e+09
 # HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 # TYPE gpfs_fs_metadata_free_bytes gauge
 gpfs_fs_metadata_free_bytes{fs="project"} 6.155570511872e+12
-# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent (ratio 0.0-1.0)
-# TYPE gpfs_fs_metadata_free_percent gauge
-gpfs_fs_metadata_free_percent{fs="project"} 0.43
 # HELP gpfs_fs_metadata_size_bytes GPFS total metadata size in bytes
 # TYPE gpfs_fs_metadata_size_bytes gauge
 gpfs_fs_metadata_size_bytes{fs="project"} 1.4224931684352e+13

--- a/cmd/gpfs_mmdf_exporter/main_test.go
+++ b/cmd/gpfs_mmdf_exporter/main_test.go
@@ -70,24 +70,24 @@ gpfs_fs_free_bytes{fs="project"} 4.92750870413312e+14
 # HELP gpfs_fs_free_inodes GPFS filesystem inodes free
 # TYPE gpfs_fs_free_inodes gauge
 gpfs_fs_free_inodes{fs="project"} 4.84301506e+08
-# HELP gpfs_fs_free_percent GPFS filesystem free percent
+# HELP gpfs_fs_free_percent GPFS filesystem free percent (ratio 0.0-1.0)
 # TYPE gpfs_fs_free_percent gauge
-gpfs_fs_free_percent{fs="project"} 14
+gpfs_fs_free_percent{fs="project"} 0.14
+# HELP gpfs_fs_inodes GPFS filesystem inodes total
+# TYPE gpfs_fs_inodes gauge
+gpfs_fs_inodes{fs="project"} 1.332164e+09
 # HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 # TYPE gpfs_fs_metadata_free_bytes gauge
 gpfs_fs_metadata_free_bytes{fs="project"} 6.155570511872e+12
-# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent
+# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent (ratio 0.0-1.0)
 # TYPE gpfs_fs_metadata_free_percent gauge
-gpfs_fs_metadata_free_percent{fs="project"} 43
-# HELP gpfs_fs_metadata_total_bytes GPFS total metadata size in bytes
-# TYPE gpfs_fs_metadata_total_bytes gauge
-gpfs_fs_metadata_total_bytes{fs="project"} 1.4224931684352e+13
-# HELP gpfs_fs_total_bytes GPFS filesystem total size in bytes
-# TYPE gpfs_fs_total_bytes gauge
-gpfs_fs_total_bytes{fs="project"} 3.749557989015552e+15
-# HELP gpfs_fs_total_inodes GPFS filesystem inodes total
-# TYPE gpfs_fs_total_inodes gauge
-gpfs_fs_total_inodes{fs="project"} 1.332164e+09
+gpfs_fs_metadata_free_percent{fs="project"} 0.43
+# HELP gpfs_fs_metadata_size_bytes GPFS total metadata size in bytes
+# TYPE gpfs_fs_metadata_size_bytes gauge
+gpfs_fs_metadata_size_bytes{fs="project"} 1.4224931684352e+13
+# HELP gpfs_fs_size_bytes GPFS filesystem total size in bytes
+# TYPE gpfs_fs_size_bytes gauge
+gpfs_fs_size_bytes{fs="project"} 3.749557989015552e+15
 # HELP gpfs_fs_used_inodes GPFS filesystem inodes used
 # TYPE gpfs_fs_used_inodes gauge
 gpfs_fs_used_inodes{fs="project"} 4.30741822e+08`

--- a/collectors/mmces.go
+++ b/collectors/mmces.go
@@ -61,7 +61,7 @@ func init() {
 func NewMmcesCollector(logger log.Logger) Collector {
 	return &MmcesCollector{
 		State: prometheus.NewDesc(prometheus.BuildFQName(namespace, "ces", "state"),
-			"GPFS CES health status, 1=healthy 0=not healthy", []string{"service", "state"}, nil),
+			"GPFS CES health status", []string{"service", "state"}, nil),
 		logger: logger,
 	}
 }
@@ -94,8 +94,7 @@ func (c *MmcesCollector) Collect(ch chan<- prometheus.Metric) {
 		errorMetric = 1
 	}
 	for _, m := range metrics {
-		statusValue := parseMmcesState(m.State)
-		ch <- prometheus.MustNewConstMetric(c.State, prometheus.GaugeValue, statusValue, m.Service, m.State)
+		ch <- prometheus.MustNewConstMetric(c.State, prometheus.GaugeValue, 1, m.Service, m.State)
 	}
 	ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, float64(errorMetric), "mmces")
 	ch <- prometheus.MustNewConstMetric(collecTimeout, prometheus.GaugeValue, float64(timeout), "mmces")
@@ -155,12 +154,4 @@ func mmces_state_show_parse(out string) []CESMetric {
 		metrics = append(metrics, metric)
 	}
 	return metrics
-}
-
-func parseMmcesState(status string) float64 {
-	if bytes.Equal([]byte(status), []byte("HEALTHY")) {
-		return 1
-	} else {
-		return 0
-	}
 }

--- a/collectors/mmces_test.go
+++ b/collectors/mmces_test.go
@@ -114,18 +114,6 @@ func TestParseMmcesStateShow(t *testing.T) {
 	}
 }
 
-func TestParseMmcesState(t *testing.T) {
-	if val := parseMmcesState("HEALTHY"); val != 1 {
-		t.Errorf("Expected 1 for HEALTHY, got %v", val)
-	}
-	if val := parseMmcesState("DISABLED"); val != 0 {
-		t.Errorf("Expected 0 for DISABLED, got %v", val)
-	}
-	if val := parseMmcesState("DEGRADED"); val != 0 {
-		t.Errorf("Expected 0 for DEGRADED, got %v", val)
-	}
-}
-
 func TestMMcesCollector(t *testing.T) {
 	if _, err := kingpin.CommandLine.Parse([]string{"--collector.mmces.nodename=ib-protocol01.domain"}); err != nil {
 		t.Fatal(err)
@@ -134,15 +122,15 @@ func TestMMcesCollector(t *testing.T) {
 		return mmcesStdout, nil
 	}
 	expected := `
-		# HELP gpfs_ces_state GPFS CES health status, 1=healthy 0=not healthy
+		# HELP gpfs_ces_state GPFS CES health status
 		# TYPE gpfs_ces_state gauge
 		gpfs_ces_state{service="AUTH",state="HEALTHY"} 1
-		gpfs_ces_state{service="AUTH_OBJ",state="DISABLED"} 0
-		gpfs_ces_state{service="BLOCK",state="DISABLED"} 0
+		gpfs_ces_state{service="AUTH_OBJ",state="DISABLED"} 1
+		gpfs_ces_state{service="BLOCK",state="DISABLED"} 1
 		gpfs_ces_state{service="CES",state="HEALTHY"} 1
 		gpfs_ces_state{service="NETWORK",state="HEALTHY"} 1
 		gpfs_ces_state{service="NFS",state="HEALTHY"} 1
-		gpfs_ces_state{service="OBJ",state="DISABLED"} 0
+		gpfs_ces_state{service="OBJ",state="DISABLED"} 1
 		gpfs_ces_state{service="SMB",state="HEALTHY"} 1
 	`
 	collector := NewMmcesCollector(log.NewNopLogger())
@@ -165,15 +153,15 @@ func TestMMcesCollectorHostname(t *testing.T) {
 		return mmcesStdout, nil
 	}
 	expected := `
-		# HELP gpfs_ces_state GPFS CES health status, 1=healthy 0=not healthy
+		# HELP gpfs_ces_state GPFS CES health status
 		# TYPE gpfs_ces_state gauge
 		gpfs_ces_state{service="AUTH",state="HEALTHY"} 1
-		gpfs_ces_state{service="AUTH_OBJ",state="DISABLED"} 0
-		gpfs_ces_state{service="BLOCK",state="DISABLED"} 0
+		gpfs_ces_state{service="AUTH_OBJ",state="DISABLED"} 1
+		gpfs_ces_state{service="BLOCK",state="DISABLED"} 1
 		gpfs_ces_state{service="CES",state="HEALTHY"} 1
 		gpfs_ces_state{service="NETWORK",state="HEALTHY"} 1
 		gpfs_ces_state{service="NFS",state="HEALTHY"} 1
-		gpfs_ces_state{service="OBJ",state="DISABLED"} 0
+		gpfs_ces_state{service="OBJ",state="DISABLED"} 1
 		gpfs_ces_state{service="SMB",state="HEALTHY"} 1
 	`
 	collector := NewMmcesCollector(log.NewNopLogger())

--- a/collectors/mmdf.go
+++ b/collectors/mmdf.go
@@ -41,40 +41,34 @@ var (
 		"inode:maxInodes":        "InodesTotal",
 		"fsTotal:fsSize":         "FSTotal",
 		"fsTotal:freeBlocks":     "FSFree",
-		"fsTotal:freeBlocksPct":  "FSFreePercent",
 		"metadata:totalMetadata": "MetadataTotal",
 		"metadata:freeBlocks":    "MetadataFree",
-		"metadata:freeBlocksPct": "MetadataFreePercent",
 	}
 	MmdfExec = mmdf
 )
 
 type DFMetric struct {
-	FS                  string
-	InodesUsed          float64
-	InodesFree          float64
-	InodesAllocated     float64
-	InodesTotal         float64
-	FSTotal             float64
-	FSFree              float64
-	FSFreePercent       float64
-	MetadataTotal       float64
-	MetadataFree        float64
-	MetadataFreePercent float64
+	FS              string
+	InodesUsed      float64
+	InodesFree      float64
+	InodesAllocated float64
+	InodesTotal     float64
+	FSTotal         float64
+	FSFree          float64
+	MetadataTotal   float64
+	MetadataFree    float64
 }
 
 type MmdfCollector struct {
-	InodesUsed          *prometheus.Desc
-	InodesFree          *prometheus.Desc
-	InodesAllocated     *prometheus.Desc
-	InodesTotal         *prometheus.Desc
-	FSTotal             *prometheus.Desc
-	FSFree              *prometheus.Desc
-	FSFreePercent       *prometheus.Desc
-	MetadataTotal       *prometheus.Desc
-	MetadataFree        *prometheus.Desc
-	MetadataFreePercent *prometheus.Desc
-	logger              log.Logger
+	InodesUsed      *prometheus.Desc
+	InodesFree      *prometheus.Desc
+	InodesAllocated *prometheus.Desc
+	InodesTotal     *prometheus.Desc
+	FSTotal         *prometheus.Desc
+	FSFree          *prometheus.Desc
+	MetadataTotal   *prometheus.Desc
+	MetadataFree    *prometheus.Desc
+	logger          log.Logger
 }
 
 func init() {
@@ -95,14 +89,10 @@ func NewMmdfCollector(logger log.Logger) Collector {
 			"GPFS filesystem total size in bytes", []string{"fs"}, nil),
 		FSFree: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "free_bytes"),
 			"GPFS filesystem free size in bytes", []string{"fs"}, nil),
-		FSFreePercent: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "free_percent"),
-			"GPFS filesystem free percent (ratio 0.0-1.0)", []string{"fs"}, nil),
 		MetadataTotal: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "metadata_size_bytes"),
 			"GPFS total metadata size in bytes", []string{"fs"}, nil),
 		MetadataFree: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "metadata_free_bytes"),
 			"GPFS metadata free size in bytes", []string{"fs"}, nil),
-		MetadataFreePercent: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fs", "metadata_free_percent"),
-			"GPFS metadata free percent (ratio 0.0-1.0)", []string{"fs"}, nil),
 		logger: logger,
 	}
 }
@@ -114,10 +104,8 @@ func (c *MmdfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.InodesTotal
 	ch <- c.FSTotal
 	ch <- c.FSFree
-	ch <- c.FSFreePercent
 	ch <- c.MetadataTotal
 	ch <- c.MetadataFree
-	ch <- c.MetadataFreePercent
 }
 
 func (c *MmdfCollector) Collect(ch chan<- prometheus.Metric) {
@@ -171,10 +159,8 @@ func (c *MmdfCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.InodesTotal, prometheus.GaugeValue, metric.InodesTotal, fs)
 			ch <- prometheus.MustNewConstMetric(c.FSTotal, prometheus.GaugeValue, metric.FSTotal, fs)
 			ch <- prometheus.MustNewConstMetric(c.FSFree, prometheus.GaugeValue, metric.FSFree, fs)
-			ch <- prometheus.MustNewConstMetric(c.FSFreePercent, prometheus.GaugeValue, metric.FSFreePercent, fs)
 			ch <- prometheus.MustNewConstMetric(c.MetadataTotal, prometheus.GaugeValue, metric.MetadataTotal, fs)
 			ch <- prometheus.MustNewConstMetric(c.MetadataFree, prometheus.GaugeValue, metric.MetadataFree, fs)
-			ch <- prometheus.MustNewConstMetric(c.MetadataFreePercent, prometheus.GaugeValue, metric.MetadataFreePercent, fs)
 			ch <- prometheus.MustNewConstMetric(lastExecution, prometheus.GaugeValue, float64(time.Now().Unix()), label)
 		}(fs)
 	}
@@ -254,9 +240,6 @@ func parse_mmdf(out string, logger log.Logger) DFMetric {
 					if val, err := strconv.ParseFloat(value, 64); err == nil {
 						if SliceContains(KbToBytes, v) {
 							val = val * 1024
-						}
-						if strings.HasSuffix(field, "Percent") {
-							val = val / 100
 						}
 						f.SetFloat(val)
 					} else {

--- a/collectors/mmdf_test.go
+++ b/collectors/mmdf_test.go
@@ -95,19 +95,19 @@ func TestMmdfTimeout(t *testing.T) {
 func TestParseMmdf(t *testing.T) {
 	dfmetrics := parse_mmdf(mmdfStdout, log.NewNopLogger())
 	if dfmetrics.InodesFree != 484301506 {
-		t.Errorf("Unexpected value for InodesFree, got %d", dfmetrics.InodesFree)
+		t.Errorf("Unexpected value for InodesFree, got %v", dfmetrics.InodesFree)
 	}
 	if dfmetrics.FSTotal != 3749557989015552 {
-		t.Errorf("Unexpected value for FSTotal, got %d", dfmetrics.FSTotal)
+		t.Errorf("Unexpected value for FSTotal, got %v", dfmetrics.FSTotal)
 	}
-	if dfmetrics.FSFreePercent != 14 {
-		t.Errorf("Unexpected value for FSFreePercent, got %d", dfmetrics.FSFreePercent)
+	if dfmetrics.FSFreePercent != 0.14 {
+		t.Errorf("Unexpected value for FSFreePercent, got %v", dfmetrics.FSFreePercent)
 	}
 	if dfmetrics.MetadataTotal != 14224931684352 {
-		t.Errorf("Unexpected value for MetadataTotal, got %d", dfmetrics.MetadataTotal)
+		t.Errorf("Unexpected value for MetadataTotal, got %v", dfmetrics.MetadataTotal)
 	}
-	if dfmetrics.MetadataFreePercent != 43 {
-		t.Errorf("Unexpected value for MetadataFreePercent, got %d", dfmetrics.MetadataFreePercent)
+	if dfmetrics.MetadataFreePercent != 0.43 {
+		t.Errorf("Unexpected value for MetadataFreePercent, got %v", dfmetrics.MetadataFreePercent)
 	}
 }
 
@@ -130,24 +130,24 @@ func TestMmdfCollector(t *testing.T) {
 		# HELP gpfs_fs_free_inodes GPFS filesystem inodes free
 		# TYPE gpfs_fs_free_inodes gauge
 		gpfs_fs_free_inodes{fs="project"} 484301506
-		# HELP gpfs_fs_free_percent GPFS filesystem free percent
+		# HELP gpfs_fs_free_percent GPFS filesystem free percent (ratio 0.0-1.0)
 		# TYPE gpfs_fs_free_percent gauge
-		gpfs_fs_free_percent{fs="project"} 14
+		gpfs_fs_free_percent{fs="project"} 0.14
+		# HELP gpfs_fs_inodes GPFS filesystem inodes total
+		# TYPE gpfs_fs_inodes gauge
+		gpfs_fs_inodes{fs="project"} 1332164000
 		# HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 		# TYPE gpfs_fs_metadata_free_bytes gauge
 		gpfs_fs_metadata_free_bytes{fs="project"} 6155570511872
-		# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent
+		# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent (ratio 0.0-1.0)
 		# TYPE gpfs_fs_metadata_free_percent gauge
-		gpfs_fs_metadata_free_percent{fs="project"} 43
-		# HELP gpfs_fs_metadata_total_bytes GPFS total metadata size in bytes
-		# TYPE gpfs_fs_metadata_total_bytes gauge
-		gpfs_fs_metadata_total_bytes{fs="project"} 14224931684352
-		# HELP gpfs_fs_total_bytes GPFS filesystem total size in bytes
-		# TYPE gpfs_fs_total_bytes gauge
-		gpfs_fs_total_bytes{fs="project"} 3749557989015552
-		# HELP gpfs_fs_total_inodes GPFS filesystem inodes total
-		# TYPE gpfs_fs_total_inodes gauge
-		gpfs_fs_total_inodes{fs="project"} 1332164000
+		gpfs_fs_metadata_free_percent{fs="project"} 0.43
+		# HELP gpfs_fs_metadata_size_bytes GPFS total metadata size in bytes
+		# TYPE gpfs_fs_metadata_size_bytes gauge
+		gpfs_fs_metadata_size_bytes{fs="project"} 14224931684352
+		# HELP gpfs_fs_size_bytes GPFS filesystem total size in bytes
+		# TYPE gpfs_fs_size_bytes gauge
+		gpfs_fs_size_bytes{fs="project"} 3749557989015552
 		# HELP gpfs_fs_used_inodes GPFS filesystem inodes used
 		# TYPE gpfs_fs_used_inodes gauge
 		gpfs_fs_used_inodes{fs="project"} 430741822
@@ -160,9 +160,9 @@ func TestMmdfCollector(t *testing.T) {
 		t.Errorf("Unexpected collection count %d, expected 14", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
-		"gpfs_fs_used_inodes", "gpfs_fs_free_inodes", "gpfs_fs_allocated_inodes", "gpfs_fs_total_inodes",
-		"gpfs_fs_free_bytes", "gpfs_fs_free_percent", "gpfs_fs_total_bytes",
-		"gpfs_fs_metadata_total_bytes", "gpfs_fs_metadata_free_bytes", "gpfs_fs_metadata_free_percent"); err != nil {
+		"gpfs_fs_used_inodes", "gpfs_fs_free_inodes", "gpfs_fs_allocated_inodes", "gpfs_fs_inodes",
+		"gpfs_fs_free_bytes", "gpfs_fs_free_percent", "gpfs_fs_size_bytes",
+		"gpfs_fs_metadata_size_bytes", "gpfs_fs_metadata_free_bytes", "gpfs_fs_metadata_free_percent"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
@@ -187,33 +187,33 @@ mmlsfs::0:1:::project:defaultMountPoint:%2Ffs%2Fproject::
 		# HELP gpfs_fs_free_bytes GPFS filesystem free size in bytes
 		# TYPE gpfs_fs_free_bytes gauge
 		gpfs_fs_free_bytes{fs="project"} 492750870413312
-		# HELP gpfs_fs_free_percent GPFS filesystem free percent
+		# HELP gpfs_fs_free_percent GPFS filesystem free percent (ratio 0.0-1.0)
 		# TYPE gpfs_fs_free_percent gauge
-		gpfs_fs_free_percent{fs="project"} 14
+		gpfs_fs_free_percent{fs="project"} 0.14
 		# HELP gpfs_fs_allocated_inodes GPFS filesystem inodes allocated
 		# TYPE gpfs_fs_allocated_inodes gauge
 		gpfs_fs_allocated_inodes{fs="project"} 915043328
 		# HELP gpfs_fs_free_inodes GPFS filesystem inodes free
 		# TYPE gpfs_fs_free_inodes gauge
 		gpfs_fs_free_inodes{fs="project"} 484301506
-		# HELP gpfs_fs_total_inodes GPFS filesystem inodes total
-		# TYPE gpfs_fs_total_inodes gauge
-		gpfs_fs_total_inodes{fs="project"} 1332164000
+		# HELP gpfs_fs_inodes GPFS filesystem inodes total
+		# TYPE gpfs_fs_inodes gauge
+		gpfs_fs_inodes{fs="project"} 1332164000
 		# HELP gpfs_fs_used_inodes GPFS filesystem inodes used
 		# TYPE gpfs_fs_used_inodes gauge
 		gpfs_fs_used_inodes{fs="project"} 430741822
 		# HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 		# TYPE gpfs_fs_metadata_free_bytes gauge
 		gpfs_fs_metadata_free_bytes{fs="project"} 6155570511872
-		# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent
+		# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent (ratio 0.0-1.0)
 		# TYPE gpfs_fs_metadata_free_percent gauge
-		gpfs_fs_metadata_free_percent{fs="project"} 43
-		# HELP gpfs_fs_metadata_total_bytes GPFS total metadata size in bytes
-		# TYPE gpfs_fs_metadata_total_bytes gauge
-		gpfs_fs_metadata_total_bytes{fs="project"} 14224931684352
-		# HELP gpfs_fs_total_bytes GPFS filesystem total size in bytes
-		# TYPE gpfs_fs_total_bytes gauge
-		gpfs_fs_total_bytes{fs="project"} 3749557989015552
+		gpfs_fs_metadata_free_percent{fs="project"} 0.43
+		# HELP gpfs_fs_metadata_size_bytes GPFS total metadata size in bytes
+		# TYPE gpfs_fs_metadata_size_bytes gauge
+		gpfs_fs_metadata_size_bytes{fs="project"} 14224931684352
+		# HELP gpfs_fs_size_bytes GPFS filesystem total size in bytes
+		# TYPE gpfs_fs_size_bytes gauge
+		gpfs_fs_size_bytes{fs="project"} 3749557989015552
 	`
 	collector := NewMmdfCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -223,9 +223,9 @@ mmlsfs::0:1:::project:defaultMountPoint:%2Ffs%2Fproject::
 		t.Errorf("Unexpected collection count %d, expected 16", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
-		"gpfs_fs_used_inodes", "gpfs_fs_free_inodes", "gpfs_fs_allocated_inodes", "gpfs_fs_total_inodes",
-		"gpfs_fs_free_bytes", "gpfs_fs_free_percent", "gpfs_fs_total_bytes",
-		"gpfs_fs_metadata_total_bytes", "gpfs_fs_metadata_free_bytes", "gpfs_fs_metadata_free_percent"); err != nil {
+		"gpfs_fs_used_inodes", "gpfs_fs_free_inodes", "gpfs_fs_allocated_inodes", "gpfs_fs_inodes",
+		"gpfs_fs_free_bytes", "gpfs_fs_free_percent", "gpfs_fs_size_bytes",
+		"gpfs_fs_metadata_size_bytes", "gpfs_fs_metadata_free_bytes", "gpfs_fs_metadata_free_percent"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }

--- a/collectors/mmdf_test.go
+++ b/collectors/mmdf_test.go
@@ -100,14 +100,8 @@ func TestParseMmdf(t *testing.T) {
 	if dfmetrics.FSTotal != 3749557989015552 {
 		t.Errorf("Unexpected value for FSTotal, got %v", dfmetrics.FSTotal)
 	}
-	if dfmetrics.FSFreePercent != 0.14 {
-		t.Errorf("Unexpected value for FSFreePercent, got %v", dfmetrics.FSFreePercent)
-	}
 	if dfmetrics.MetadataTotal != 14224931684352 {
 		t.Errorf("Unexpected value for MetadataTotal, got %v", dfmetrics.MetadataTotal)
-	}
-	if dfmetrics.MetadataFreePercent != 0.43 {
-		t.Errorf("Unexpected value for MetadataFreePercent, got %v", dfmetrics.MetadataFreePercent)
 	}
 }
 
@@ -130,18 +124,12 @@ func TestMmdfCollector(t *testing.T) {
 		# HELP gpfs_fs_free_inodes GPFS filesystem inodes free
 		# TYPE gpfs_fs_free_inodes gauge
 		gpfs_fs_free_inodes{fs="project"} 484301506
-		# HELP gpfs_fs_free_percent GPFS filesystem free percent (ratio 0.0-1.0)
-		# TYPE gpfs_fs_free_percent gauge
-		gpfs_fs_free_percent{fs="project"} 0.14
 		# HELP gpfs_fs_inodes GPFS filesystem inodes total
 		# TYPE gpfs_fs_inodes gauge
 		gpfs_fs_inodes{fs="project"} 1332164000
 		# HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 		# TYPE gpfs_fs_metadata_free_bytes gauge
 		gpfs_fs_metadata_free_bytes{fs="project"} 6155570511872
-		# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent (ratio 0.0-1.0)
-		# TYPE gpfs_fs_metadata_free_percent gauge
-		gpfs_fs_metadata_free_percent{fs="project"} 0.43
 		# HELP gpfs_fs_metadata_size_bytes GPFS total metadata size in bytes
 		# TYPE gpfs_fs_metadata_size_bytes gauge
 		gpfs_fs_metadata_size_bytes{fs="project"} 14224931684352
@@ -156,8 +144,8 @@ func TestMmdfCollector(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 14 {
-		t.Errorf("Unexpected collection count %d, expected 14", val)
+	} else if val != 12 {
+		t.Errorf("Unexpected collection count %d, expected 12", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"gpfs_fs_used_inodes", "gpfs_fs_free_inodes", "gpfs_fs_allocated_inodes", "gpfs_fs_inodes",
@@ -187,9 +175,6 @@ mmlsfs::0:1:::project:defaultMountPoint:%2Ffs%2Fproject::
 		# HELP gpfs_fs_free_bytes GPFS filesystem free size in bytes
 		# TYPE gpfs_fs_free_bytes gauge
 		gpfs_fs_free_bytes{fs="project"} 492750870413312
-		# HELP gpfs_fs_free_percent GPFS filesystem free percent (ratio 0.0-1.0)
-		# TYPE gpfs_fs_free_percent gauge
-		gpfs_fs_free_percent{fs="project"} 0.14
 		# HELP gpfs_fs_allocated_inodes GPFS filesystem inodes allocated
 		# TYPE gpfs_fs_allocated_inodes gauge
 		gpfs_fs_allocated_inodes{fs="project"} 915043328
@@ -205,9 +190,6 @@ mmlsfs::0:1:::project:defaultMountPoint:%2Ffs%2Fproject::
 		# HELP gpfs_fs_metadata_free_bytes GPFS metadata free size in bytes
 		# TYPE gpfs_fs_metadata_free_bytes gauge
 		gpfs_fs_metadata_free_bytes{fs="project"} 6155570511872
-		# HELP gpfs_fs_metadata_free_percent GPFS metadata free percent (ratio 0.0-1.0)
-		# TYPE gpfs_fs_metadata_free_percent gauge
-		gpfs_fs_metadata_free_percent{fs="project"} 0.43
 		# HELP gpfs_fs_metadata_size_bytes GPFS total metadata size in bytes
 		# TYPE gpfs_fs_metadata_size_bytes gauge
 		gpfs_fs_metadata_size_bytes{fs="project"} 14224931684352
@@ -219,8 +201,8 @@ mmlsfs::0:1:::project:defaultMountPoint:%2Ffs%2Fproject::
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 16 {
-		t.Errorf("Unexpected collection count %d, expected 16", val)
+	} else if val != 14 {
+		t.Errorf("Unexpected collection count %d, expected 14", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"gpfs_fs_used_inodes", "gpfs_fs_free_inodes", "gpfs_fs_allocated_inodes", "gpfs_fs_inodes",

--- a/collectors/mmhealth.go
+++ b/collectors/mmhealth.go
@@ -58,7 +58,7 @@ func init() {
 func NewMmhealthCollector(logger log.Logger) Collector {
 	return &MmhealthCollector{
 		State: prometheus.NewDesc(prometheus.BuildFQName(namespace, "health", "status"),
-			"GPFS health status, 1=healthy 0=not healthy", []string{"component", "entityname", "entitytype", "status"}, nil),
+			"GPFS health status", []string{"component", "entityname", "entitytype", "status"}, nil),
 		logger: logger,
 	}
 }
@@ -81,8 +81,7 @@ func (c *MmhealthCollector) Collect(ch chan<- prometheus.Metric) {
 		errorMetric = 1
 	}
 	for _, m := range metrics {
-		statusValue := parseMmhealthStatus(m.Status)
-		ch <- prometheus.MustNewConstMetric(c.State, prometheus.GaugeValue, statusValue, m.Component, m.EntityName, m.EntityType, m.Status)
+		ch <- prometheus.MustNewConstMetric(c.State, prometheus.GaugeValue, 1, m.Component, m.EntityName, m.EntityType, m.Status)
 	}
 	ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, float64(errorMetric), "mmhealth")
 	ch <- prometheus.MustNewConstMetric(collecTimeout, prometheus.GaugeValue, float64(timeout), "mmhealth")
@@ -155,12 +154,4 @@ func mmhealth_parse(out string, logger log.Logger) []HealthMetric {
 		metrics = append(metrics, metric)
 	}
 	return metrics
-}
-
-func parseMmhealthStatus(status string) float64 {
-	if bytes.Equal([]byte(status), []byte("HEALTHY")) {
-		return 1
-	} else {
-		return 0
-	}
 }

--- a/collectors/mmhealth_test.go
+++ b/collectors/mmhealth_test.go
@@ -111,18 +111,6 @@ func TestParseMmhealth(t *testing.T) {
 	}
 }
 
-func TestParseMmhealthStatus(t *testing.T) {
-	if val := parseMmhealthStatus("HEALTHY"); val != 1 {
-		t.Errorf("Expected 1 for HEALTHY, got %v", val)
-	}
-	if val := parseMmhealthStatus("TIPS"); val != 0 {
-		t.Errorf("Expected 0 for TIPS, got %v", val)
-	}
-	if val := parseMmhealthStatus("DEGRADED"); val != 0 {
-		t.Errorf("Expected 0 for DEGRADED, got %v", val)
-	}
-}
-
 func TestMmhealthCollector(t *testing.T) {
 	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
 		t.Fatal(err)
@@ -131,17 +119,17 @@ func TestMmhealthCollector(t *testing.T) {
 		return mmhealthStdout, nil
 	}
 	expected := `
-		# HELP gpfs_health_status GPFS health status, 1=healthy 0=not healthy
+		# HELP gpfs_health_status GPFS health status
 		# TYPE gpfs_health_status gauge
 		gpfs_health_status{component="FILESYSTEM",entityname="ib-haswell1.example.com",entitytype="NODE",status="HEALTHY"} 1
 		gpfs_health_status{component="FILESYSTEM",entityname="project",entitytype="FILESYSTEM",status="HEALTHY"} 1
 		gpfs_health_status{component="FILESYSTEM",entityname="scratch",entitytype="FILESYSTEM",status="HEALTHY"} 1
 		gpfs_health_status{component="FILESYSTEM",entityname="ess",entitytype="FILESYSTEM",status="HEALTHY"} 1
-		gpfs_health_status{component="GPFS",entityname="ib-haswell1.example.com",entitytype="NODE",status="TIPS"} 0
+		gpfs_health_status{component="GPFS",entityname="ib-haswell1.example.com",entitytype="NODE",status="TIPS"} 1
 		gpfs_health_status{component="NETWORK",entityname="ib-haswell1.example.com",entitytype="NODE",status="HEALTHY"} 1
 		gpfs_health_status{component="NETWORK",entityname="ib0",entitytype="NIC",status="HEALTHY"} 1
 		gpfs_health_status{component="NETWORK",entityname="mlx5_0/1",entitytype="IB_RDMA",status="HEALTHY"} 1
-		gpfs_health_status{component="NODE",entityname="ib-haswell1.example.com",entitytype="NODE",status="TIPS"} 0
+		gpfs_health_status{component="NODE",entityname="ib-haswell1.example.com",entitytype="NODE",status="TIPS"} 1
 	`
 	collector := NewMmhealthCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)

--- a/collectors/mmpmon_test.go
+++ b/collectors/mmpmon_test.go
@@ -112,37 +112,42 @@ func TestMmpmonCollector(t *testing.T) {
 		return mmpmonStdout, nil
 	}
 	expected := `
+		# HELP gpfs_perf_info GPFS client information
+		# TYPE gpfs_perf_info gauge
+		gpfs_perf_info{fs="project",nodename="ib-pitzer-rw02.ten"} 1
+		gpfs_perf_info{fs="scratch",nodename="ib-pitzer-rw02.ten"} 1
 		# HELP gpfs_perf_operations_total GPFS operationgs reported by mmpmon
 		# TYPE gpfs_perf_operations_total counter
-		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="closes"} 513
-		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="inode_updates"} 169
-		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="opens"} 513
-		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="read_dir"} 0
-		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="reads"} 0
-		gpfs_perf_operations_total{fs="project",nodename="ib-pitzer-rw02.ten",operation="writes"} 0
-		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="closes"} 2201576
-		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="inode_updates"} 544768
-		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="opens"} 2377656
-		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="read_dir"} 40971
-		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="reads"} 59420404
-		gpfs_perf_operations_total{fs="scratch",nodename="ib-pitzer-rw02.ten",operation="writes"} 18874626
+		gpfs_perf_operations_total{fs="project",operation="closes"} 513
+		gpfs_perf_operations_total{fs="project",operation="inode_updates"} 169
+		gpfs_perf_operations_total{fs="project",operation="opens"} 513
+		gpfs_perf_operations_total{fs="project",operation="read_dir"} 0
+		gpfs_perf_operations_total{fs="project",operation="reads"} 0
+		gpfs_perf_operations_total{fs="project",operation="writes"} 0
+		gpfs_perf_operations_total{fs="scratch",operation="closes"} 2201576
+		gpfs_perf_operations_total{fs="scratch",operation="inode_updates"} 544768
+		gpfs_perf_operations_total{fs="scratch",operation="opens"} 2377656
+		gpfs_perf_operations_total{fs="scratch",operation="read_dir"} 40971
+		gpfs_perf_operations_total{fs="scratch",operation="reads"} 59420404
+		gpfs_perf_operations_total{fs="scratch",operation="writes"} 18874626
 		# HELP gpfs_perf_read_bytes_total GPFS read bytes
 		# TYPE gpfs_perf_read_bytes_total counter
-		gpfs_perf_read_bytes_total{fs="project",nodename="ib-pitzer-rw02.ten"} 0
-		gpfs_perf_read_bytes_total{fs="scratch",nodename="ib-pitzer-rw02.ten"} 2.05607400434e+11
+		gpfs_perf_read_bytes_total{fs="project"} 0
+		gpfs_perf_read_bytes_total{fs="scratch"} 2.05607400434e+11
 		# HELP gpfs_perf_write_bytes_total GPFS write bytes
 		# TYPE gpfs_perf_write_bytes_total counter
-		gpfs_perf_write_bytes_total{fs="project",nodename="ib-pitzer-rw02.ten"} 0
-		gpfs_perf_write_bytes_total{fs="scratch",nodename="ib-pitzer-rw02.ten"} 74839282351
+		gpfs_perf_write_bytes_total{fs="project"} 0
+		gpfs_perf_write_bytes_total{fs="scratch"} 74839282351
 	`
 	collector := NewMmpmonCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 19 {
-		t.Errorf("Unexpected collection count %d, expected 19", val)
+	} else if val != 21 {
+		t.Errorf("Unexpected collection count %d, expected 21", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
+		"gpfs_perf_info",
 		"gpfs_perf_read_bytes_total", "gpfs_perf_write_bytes_total", "gpfs_perf_operations_total"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}


### PR DESCRIPTION
* mmces and mmhealth status metrics will always have value 1, only the `status` label will change
* Renames:
  * gpfs_fs_total_inodes to gpfs_fs_inodes
  * gpfs_fs_total_bytes to gpfs_fs_size_bytes
  * gpfs_fs_metadata_total_bytes to gpfs_fs_metadata_size_bytes
* Removed metrics that can be calculated using other metrics
  * gpfs_fs_metadata_free_percent
  * gpfs_fs_free_percent metrics
* Remove nodename label from gpfs_perf_* metrics, replace with gpfs_perf_info metric