### PR TITLE
Add possibility to run mmlsqos command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ mmces | Collect state of CES | Disabled
 mmrepquota | Collect fileset quota information | Disabled
 mmlssnapshot | Collect GPFS snapshot information | Disabled
 mmlsfileset | Collect GPFS fileset information | Disabled
+mmlsqos | Collect GPFS I/O performance values of a file system, when you enable Quality of Service | Disabled
 
 ### mount
 
@@ -74,6 +75,15 @@ The exporter `gpfs_mmlssnapshot_exporter` is provided to allow snapshot collecti
 
 **NOTE**: This collector does not collect used inodes. To get used inodes look at using the [mmrepquota](#mmrepquota) collector.
 
+### mmlsqos
+
+Displays the I/O performance values of a file system, when you enable Quality of Service for I/O operations (QoS) with the mmchqos command.
+
+Flags:
+* `--collector.mmlsqos.filesystems` - A comma separated list of filesystems to collect. Default is to collect all filesystems listed by `mmlsfs`.
+* `--collector.mmlsqos.timeout` - Count of seconds for running mmlsqos command before timeout error will be raised. Default value is 60 seconds.
+* `--collector.mmlsqos.seconds` - Displays the I/O performance values for the previous number of seconds. The valid range of seconds is 1-999. The default value is 60 seconds.
+
 ## Sudo
 
 Ensure the user running `gpfs_exporter` can execute GPFS commands necessary to collect metrics.
@@ -110,6 +120,9 @@ gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlssnapshot project -s all -
 gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlssnapshot ess -s all -Y
 # mmlsfileset collector, each filesystem must be listed
 gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsfileset project -Y
+gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsfileset ess -Y
+# mmlsqos collector, each filesystem must be listed
+gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsqos mmfs1 -Y
 gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsfileset ess -Y
 ```
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsfileset project -Y
 gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsfileset ess -Y
 # mmlsqos collector, each filesystem must be listed
 gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsqos mmfs1 -Y
-gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsfileset ess -Y
+gpfs_exporter ALL=(ALL) NOPASSWD:/usr/lpp/mmfs/bin/mmlsqos ess -Y
 ```
 
 ## Install

--- a/collectors/mmlsqos.go
+++ b/collectors/mmlsqos.go
@@ -46,23 +46,23 @@ var (
 )
 
 type QosMetric struct {
-	Pool                    string
-	Time                    float64
-	Class                   string
-	Iops                    float64
-	AvegarePendingRequests  float64
-	AvegareQueuedRequests   float64
-	MeasurementInterval     float64
-	Bs                      float64
+	Pool                   string
+	Time                   float64
+	Class                  string
+	Iops                   float64
+	AvegarePendingRequests float64
+	AvegareQueuedRequests  float64
+	MeasurementInterval    float64
+	Bs                     float64
 }
 
 type MmlsqosCollector struct {
-	Iops                    *prometheus.Desc
-	AvegarePendingRequests  *prometheus.Desc
-	AvegareQueuedRequests   *prometheus.Desc
-	MeasurementInterval     *prometheus.Desc
-	Bs                      *prometheus.Desc
-	logger log.Logger
+	Iops                   *prometheus.Desc
+	AvegarePendingRequests *prometheus.Desc
+	AvegareQueuedRequests  *prometheus.Desc
+	MeasurementInterval    *prometheus.Desc
+	Bs                     *prometheus.Desc
+	logger                 log.Logger
 }
 
 func init() {

--- a/collectors/mmlsqos.go
+++ b/collectors/mmlsqos.go
@@ -140,11 +140,11 @@ func (c *MmlsqosCollector) Collect(ch chan<- prometheus.Metric) {
 				return
 			}
 			for _, m := range metrics {
-				ch <- prometheus.MustNewConstMetric(c.Iops, prometheus.GaugeValue, m.Iops, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
-				ch <- prometheus.MustNewConstMetric(c.Ioql, prometheus.GaugeValue, m.Ioql, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
-				ch <- prometheus.MustNewConstMetric(c.Qsdl, prometheus.GaugeValue, m.Qsdl, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
-				ch <- prometheus.MustNewConstMetric(c.ET, prometheus.GaugeValue, m.ET, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
-				ch <- prometheus.MustNewConstMetric(c.MBs, prometheus.GaugeValue, m.MBs, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.Iops, prometheus.GaugeValue, m.Iops, fs, m.Pool, m.Class, fmt.Sprintf("%.f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.Ioql, prometheus.GaugeValue, m.Ioql, fs, m.Pool, m.Class, fmt.Sprintf("%.f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.Qsdl, prometheus.GaugeValue, m.Qsdl, fs, m.Pool, m.Class, fmt.Sprintf("%.f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.ET, prometheus.GaugeValue, m.ET, fs, m.Pool, m.Class, fmt.Sprintf("%.f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.MBs, prometheus.GaugeValue, m.MBs, fs, m.Pool, m.Class, fmt.Sprintf("%.f", m.Time))
 			}
 		}(fs)
 	}

--- a/collectors/mmlsqos.go
+++ b/collectors/mmlsqos.go
@@ -1,0 +1,225 @@
+// Copyright 2020 Trey Dockendorf
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package collectors
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	qosFilesystems = kingpin.Flag("collector.mmlsqos.filesystems", "Filesystems to query with mmlsqos, comma separated. Defaults to all filesystems.").Default("").String()
+	qosTimeout     = kingpin.Flag("collector.mmlsqos.timeout", "Timeout for mmlsqos execution").Default("60").Int()
+	qosSeconds     = kingpin.Flag("collector.mmlsqos.seconds", "Display the I/O performance values for the previous number of seconds. The valid range of seconds is 1-999").Default("60").Int()
+	qosMap         = map[string]string{
+		"pool":      "Pool",
+		"timeEpoch": "Time",
+		"class":     "Class",
+		"iops":      "Iops",
+		"ioql":      "Ioql",
+		"qsdl":      "Qsdl",
+		"et":        "ET",
+		"MBs":       "MBs",
+	}
+	MmlsqosExec = mmlsqos
+)
+
+type QosMetric struct {
+	Pool   string
+	Time   float64
+	Class  string
+	Iops   float64
+	Ioql   float64
+	Qsdl   float64
+	ET     float64
+	MBs    float64
+}
+
+type MmlsqosCollector struct {
+	Iops   *prometheus.Desc
+	Ioql   *prometheus.Desc
+	Qsdl   *prometheus.Desc
+	ET     *prometheus.Desc
+	MBs    *prometheus.Desc
+	logger log.Logger
+}
+
+func init() {
+	registerCollector("mmlsqos", false, NewMmlsqosCollector)
+}
+
+func NewMmlsqosCollector(logger log.Logger) Collector {
+	labels := []string{"fs", "pool", "class", "measurement_period_seconds"}
+	return &MmlsqosCollector{
+		Iops: prometheus.NewDesc(prometheus.BuildFQName(namespace, "qos", "iops"),
+			"GPFS performance of the class in I/O operations per second", labels, nil),
+		Ioql: prometheus.NewDesc(prometheus.BuildFQName(namespace, "qos", "ioql"),
+			"GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS", labels, nil),
+		Qsdl: prometheus.NewDesc(prometheus.BuildFQName(namespace, "qos", "qsdl"),
+			"GPFS average number of I/O requests in the class that are queued by QoS", labels, nil),
+		ET: prometheus.NewDesc(prometheus.BuildFQName(namespace, "qos", "et_seconds"),
+			"GPFS interval in seconds during which the measurement was made", labels, nil),
+		MBs: prometheus.NewDesc(prometheus.BuildFQName(namespace, "qos", "mbs"),
+			"GPFS performance of the class in MegaBytes per second", labels, nil),
+		logger: logger,
+	}
+}
+
+func (c *MmlsqosCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.Iops
+	ch <- c.Ioql
+	ch <- c.Qsdl
+	ch <- c.ET
+	ch <- c.MBs
+}
+
+func (c *MmlsqosCollector) Collect(ch chan<- prometheus.Metric) {
+	wg := &sync.WaitGroup{}
+	var filesystems []string
+	if *qosFilesystems == "" {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*mmlsfsTimeout)*time.Second)
+		defer cancel()
+		var mmlsfsTimeout float64
+		var mmlsfsError float64
+		mmlfsfs_filesystems, err := mmlfsfsFilesystems(ctx, c.logger)
+		if err == context.DeadlineExceeded {
+			mmlsfsTimeout = 1
+			level.Error(c.logger).Log("msg", "Timeout executing mmlsfs")
+		} else if err != nil {
+			mmlsfsError = 1
+			level.Error(c.logger).Log("msg", err)
+		}
+		ch <- prometheus.MustNewConstMetric(collecTimeout, prometheus.GaugeValue, mmlsfsTimeout, "mmlsqos-mmlsfs")
+		ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, mmlsfsError, "mmlsqos-mmlsfs")
+		filesystems = mmlfsfs_filesystems
+	} else {
+		filesystems = strings.Split(*qosFilesystems, ",")
+	}
+	for _, fs := range filesystems {
+		level.Debug(c.logger).Log("msg", "Collecting mmlsqos metrics", "fs", fs)
+		wg.Add(1)
+		collectTime := time.Now()
+		go func(fs string) {
+			defer wg.Done()
+			label := fmt.Sprintf("mmlsqos-%s", fs)
+			timeout := 0
+			errorMetric := 0
+			metrics, err := c.mmlsqosCollect(fs)
+			if err == context.DeadlineExceeded {
+				level.Error(c.logger).Log("msg", fmt.Sprintf("Timeout executing %s", label))
+				timeout = 1
+			} else if err != nil {
+				level.Error(c.logger).Log("msg", err, "fs", fs)
+				errorMetric = 1
+			}
+			ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, float64(errorMetric), label)
+			ch <- prometheus.MustNewConstMetric(collecTimeout, prometheus.GaugeValue, float64(timeout), label)
+			ch <- prometheus.MustNewConstMetric(collectDuration, prometheus.GaugeValue, time.Since(collectTime).Seconds(), label)
+			if err != nil {
+				return
+			}
+			for _, m := range metrics {
+				ch <- prometheus.MustNewConstMetric(c.Iops, prometheus.GaugeValue, m.Iops, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.Ioql, prometheus.GaugeValue, m.Ioql, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.Qsdl, prometheus.GaugeValue, m.Qsdl, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.ET, prometheus.GaugeValue, m.ET, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
+				ch <- prometheus.MustNewConstMetric(c.MBs, prometheus.GaugeValue, m.MBs, fs, m.Pool, m.Class, fmt.Sprintf("%.2f", m.Time))
+			}
+		}(fs)
+	}
+	wg.Wait()
+}
+
+func (c *MmlsqosCollector) mmlsqosCollect(fs string) ([]QosMetric, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*qosTimeout)*time.Second)
+	defer cancel()
+	out, err := MmlsqosExec(fs, ctx)
+	if err != nil {
+		return nil, err
+	}
+	metrics, err := parse_mmlsqos(out, c.logger)
+	return metrics, err
+}
+
+func mmlsqos(fs string, ctx context.Context) (string, error) {
+	args := []string{"/usr/lpp/mmfs/bin/mmlsqos", fs, "-Y", "--seconds", strconv.Itoa(*qosSeconds)}
+	cmd := execCommand(ctx, *sudoCmd, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", ctx.Err()
+	} else if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+func parse_mmlsqos(out string, logger log.Logger) ([]QosMetric, error) {
+	var metrics []QosMetric
+	headers := []string{}
+	lines := strings.Split(out, "\n")
+	for _, l := range lines {
+		if !strings.HasPrefix(l, "mmlsqos") {
+			continue
+		}
+		items := strings.Split(l, ":")
+		if len(items) < 3 {
+			continue
+		}
+		if items[1] != "stats" {
+			continue
+		}
+		var values []string
+		if items[2] == "HEADER" {
+			headers = append(headers, items...)
+			continue
+		} else {
+			values = append(values, items...)
+		}
+		var metric QosMetric
+		ps := reflect.ValueOf(&metric) // pointer to struct - addressable
+		s := ps.Elem()                 // struct
+		for i, h := range headers {
+			if field, ok := qosMap[h]; ok {
+				f := s.FieldByName(field)
+				if f.Kind() == reflect.String {
+					f.SetString(values[i])
+				} else if f.Kind() == reflect.Float64 {
+					if values[i] == "nan" {
+						f.SetFloat(0)
+					} else if val, err := strconv.ParseFloat(strings.Replace(values[i], ",", ".", -1), 64); err == nil {
+						f.SetFloat(val)
+					} else {
+						level.Error(logger).Log("msg", fmt.Sprintf("Error parsing %s value %s: %s", h, values[i], err.Error()))
+						return nil, err
+					}
+				}
+			}
+		}
+
+		metrics = append(metrics, metric)
+	}
+	return metrics, nil
+}

--- a/collectors/mmlsqos.go
+++ b/collectors/mmlsqos.go
@@ -80,7 +80,7 @@ func NewMmlsqosCollector(logger log.Logger) Collector {
 			"GPFS average number of I/O requests in the class that are queued by QoS", labels, nil),
 		MeasurementInterval: prometheus.NewDesc(prometheus.BuildFQName(namespace, "qos", "measurement_interval_seconds"),
 			"GPFS interval in seconds during which the measurement was made", labels, nil),
-		Bs: prometheus.NewDesc(prometheus.BuildFQName(namespace, "qos", "bs"),
+		Bs: prometheus.NewDesc(prometheus.BuildFQName(namespace, "qos", "bytes_per_second"),
 			"GPFS performance of the class in Bytes per second", labels, nil),
 		logger: logger,
 	}

--- a/collectors/mmlsqos.go
+++ b/collectors/mmlsqos.go
@@ -46,14 +46,14 @@ var (
 )
 
 type QosMetric struct {
-	Pool   string
-	Time   float64
-	Class  string
-	Iops   float64
-	Ioql   float64
-	Qsdl   float64
-	ET     float64
-	MBs    float64
+	Pool  string
+	Time  float64
+	Class string
+	Iops  float64
+	Ioql  float64
+	Qsdl  float64
+	ET    float64
+	MBs   float64
 }
 
 type MmlsqosCollector struct {

--- a/collectors/mmlsqos_test.go
+++ b/collectors/mmlsqos_test.go
@@ -205,13 +205,13 @@ func TestMmlsqosCollector(t *testing.T) {
         gpfs_qos_average_queued_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.0055852
         gpfs_qos_average_queued_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 7.734906573251e+07
         gpfs_qos_average_queued_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.9398e+08
-        # HELP gpfs_qos_bs GPFS performance of the class in Bytes per second
-        # TYPE gpfs_qos_bs gauge
-        gpfs_qos_bs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 273.07016192
-        gpfs_qos_bs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.9020928e+06
-        gpfs_qos_bs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 2.232942592e+08
-        gpfs_qos_bs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.599602688e+09
-        gpfs_qos_bs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.5703474176e+08
+        # HELP gpfs_qos_bytes_per_second GPFS performance of the class in Bytes per second
+        # TYPE gpfs_qos_bytes_per_second gauge
+        gpfs_qos_bytes_per_second{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 273.07016192
+        gpfs_qos_bytes_per_second{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.9020928e+06
+        gpfs_qos_bytes_per_second{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 2.232942592e+08
+        gpfs_qos_bytes_per_second{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.599602688e+09
+        gpfs_qos_bytes_per_second{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.5703474176e+08
         # HELP gpfs_qos_iops GPFS performance of the class in I/O operations per second
         # TYPE gpfs_qos_iops gauge
         gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.066667
@@ -236,7 +236,7 @@ func TestMmlsqosCollector(t *testing.T) {
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_measurement_interval_seconds",
-		"gpfs_qos_iops", "gpfs_qos_average_pending_requests", "gpfs_qos_bs",
+		"gpfs_qos_iops", "gpfs_qos_average_pending_requests", "gpfs_qos_bytes_per_second",
 		"gpfs_qos_average_queued_requests"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
@@ -271,13 +271,13 @@ func TestMmlsqosCollectorMmlsfs(t *testing.T) {
         gpfs_qos_average_queued_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.0055852
         gpfs_qos_average_queued_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 7.734906573251e+07
         gpfs_qos_average_queued_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.9398e+08
-        # HELP gpfs_qos_bs GPFS performance of the class in Bytes per second
-        # TYPE gpfs_qos_bs gauge
-        gpfs_qos_bs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 273.07016192
-        gpfs_qos_bs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.9020928e+06
-        gpfs_qos_bs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 2.232942592e+08
-        gpfs_qos_bs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.599602688e+09
-        gpfs_qos_bs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.5703474176e+08
+        # HELP gpfs_qos_bytes_per_second GPFS performance of the class in Bytes per second
+        # TYPE gpfs_qos_bytes_per_second gauge
+        gpfs_qos_bytes_per_second{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 273.07016192
+        gpfs_qos_bytes_per_second{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.9020928e+06
+        gpfs_qos_bytes_per_second{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 2.232942592e+08
+        gpfs_qos_bytes_per_second{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.599602688e+09
+        gpfs_qos_bytes_per_second{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.5703474176e+08
         # HELP gpfs_qos_iops GPFS performance of the class in I/O operations per second
         # TYPE gpfs_qos_iops gauge
         gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.066667
@@ -302,7 +302,7 @@ func TestMmlsqosCollectorMmlsfs(t *testing.T) {
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_measurement_interval_seconds",
-		"gpfs_qos_iops", "gpfs_qos_average_pending_requests", "gpfs_qos_bs",
+		"gpfs_qos_iops", "gpfs_qos_average_pending_requests", "gpfs_qos_bytes_per_second",
 		"gpfs_qos_average_queued_requests"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}

--- a/collectors/mmlsqos_test.go
+++ b/collectors/mmlsqos_test.go
@@ -193,39 +193,39 @@ func TestMmlsqosCollector(t *testing.T) {
 	expected := `
 # HELP gpfs_qos_et_seconds GPFS interval in seconds during which the measurement was made
         # TYPE gpfs_qos_et_seconds gauge
-        gpfs_qos_et_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
-        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 30
-        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
-        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 30
-        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
+        gpfs_qos_et_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
+        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
+        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
         # HELP gpfs_qos_iops GPFS performance of the class in I/O operations per second
         # TYPE gpfs_qos_iops gauge
-        gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.066667
-        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 33.267
-        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 24875
-        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 829.83
-        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 35545
+        gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.066667
+        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 33.267
+        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 24875
+        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 829.83
+        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 35545
         # HELP gpfs_qos_ioql GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS
         # TYPE gpfs_qos_ioql gauge
-        gpfs_qos_ioql{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 5.579e-05
-        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 0.013449
-        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 1.7781e+08
-        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 0.85256
-        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 41.399
+        gpfs_qos_ioql{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 5.579e-05
+        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.013449
+        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.7781e+08
+        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.85256
+        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 41.399
         # HELP gpfs_qos_mbs GPFS performance of the class in MegaBytes per second
         # TYPE gpfs_qos_mbs gauge
-        gpfs_qos_mbs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.00026042
-        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 4.675
-        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 212.95
-        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 1525.5
-        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 149.76
+        gpfs_qos_mbs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.00026042
+        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.675
+        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 212.95
+        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1525.5
+        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 149.76
         # HELP gpfs_qos_qsdl GPFS average number of I/O requests in the class that are queued by QoS
         # TYPE gpfs_qos_qsdl gauge
-        gpfs_qos_qsdl{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0
-        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 1.0751e-05
-        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.0055852
-        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 7.734906573251e+07
-        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 1.9398e+08
+        gpfs_qos_qsdl{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0
+        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.0751e-05
+        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.0055852
+        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 7.734906573251e+07
+        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.9398e+08
 	`
 	collector := NewMmlsqosCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -258,39 +258,39 @@ func TestMmlsqosCollectorMmlsfs(t *testing.T) {
 	expected := `
 # HELP gpfs_qos_et_seconds GPFS interval in seconds during which the measurement was made
         # TYPE gpfs_qos_et_seconds gauge
-        gpfs_qos_et_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
-        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 30
-        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
-        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 30
-        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
+        gpfs_qos_et_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
+        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
+        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
         # HELP gpfs_qos_iops GPFS performance of the class in I/O operations per second
         # TYPE gpfs_qos_iops gauge
-        gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.066667
-        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 33.267
-        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 24875
-        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 829.83
-        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 35545
+        gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.066667
+        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 33.267
+        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 24875
+        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 829.83
+        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 35545
         # HELP gpfs_qos_ioql GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS
         # TYPE gpfs_qos_ioql gauge
-        gpfs_qos_ioql{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 5.579e-05
-        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 0.013449
-        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 1.7781e+08
-        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 0.85256
-        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 41.399
+        gpfs_qos_ioql{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 5.579e-05
+        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.013449
+        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.7781e+08
+        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.85256
+        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 41.399
         # HELP gpfs_qos_mbs GPFS performance of the class in MegaBytes per second
         # TYPE gpfs_qos_mbs gauge
-        gpfs_qos_mbs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.00026042
-        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 4.675
-        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 212.95
-        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 1525.5
-        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 149.76
+        gpfs_qos_mbs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.00026042
+        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.675
+        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 212.95
+        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1525.5
+        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 149.76
         # HELP gpfs_qos_qsdl GPFS average number of I/O requests in the class that are queued by QoS
         # TYPE gpfs_qos_qsdl gauge
-        gpfs_qos_qsdl{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0
-        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 1.0751e-05
-        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.0055852
-        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 7.734906573251e+07
-        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 1.9398e+08
+        gpfs_qos_qsdl{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0
+        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.0751e-05
+        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.0055852
+        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 7.734906573251e+07
+        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.9398e+08
 	`
 	collector := NewMmlsqosCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)

--- a/collectors/mmlsqos_test.go
+++ b/collectors/mmlsqos_test.go
@@ -237,7 +237,7 @@ func TestMmlsqosCollector(t *testing.T) {
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_measurement_interval_seconds",
 		"gpfs_qos_iops", "gpfs_qos_average_pending_requests", "gpfs_qos_bs",
-		 "gpfs_qos_average_queued_requests"); err != nil {
+		"gpfs_qos_average_queued_requests"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
@@ -303,7 +303,7 @@ func TestMmlsqosCollectorMmlsfs(t *testing.T) {
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_measurement_interval_seconds",
 		"gpfs_qos_iops", "gpfs_qos_average_pending_requests", "gpfs_qos_bs",
-		 "gpfs_qos_average_queued_requests"); err != nil {
+		"gpfs_qos_average_queued_requests"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }

--- a/collectors/mmlsqos_test.go
+++ b/collectors/mmlsqos_test.go
@@ -146,25 +146,25 @@ func TestParseMmlsqos(t *testing.T) {
 	if metrics[0].Iops != 33.267 {
 		t.Errorf("Unexpected value for Iops, got %v", metrics[0].Iops)
 	}
-	if metrics[0].Ioql != 0.013449 {
-		t.Errorf("Unexpected value for Ioql, got %v", metrics[0].Ioql)
+	if metrics[0].AvegarePendingRequests != 0.013449 {
+		t.Errorf("Unexpected value for AvegarePendingRequests, got %v", metrics[0].AvegarePendingRequests)
 	}
-	if metrics[0].Qsdl != 1.0751e-05 {
-		t.Errorf("Unexpected value for Qsdl, got %v", metrics[0].Qsdl)
+	if metrics[0].AvegareQueuedRequests != 1.0751e-05 {
+		t.Errorf("Unexpected value for AvegareQueuedRequests, got %v", metrics[0].AvegareQueuedRequests)
 	}
-	if metrics[0].ET != 30 {
-		t.Errorf("Unexpected value for ET, got %v", metrics[0].ET)
+	if metrics[0].MeasurementInterval != 30 {
+		t.Errorf("Unexpected value for MeasurementInterval, got %v", metrics[0].MeasurementInterval)
 	}
-	if metrics[0].MBs != 4.675 {
-		t.Errorf("Unexpected value for MBs, got %v", metrics[0].MBs)
+	if metrics[0].Bs != 4902092.8 {
+		t.Errorf("Unexpected value for Bs, got %v", metrics[0].Bs)
 	}
 	metrics, err = parse_mmlsqos(mmlsqosStdoutNanValue, log.NewNopLogger())
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return
 	}
-	if metrics[0].Qsdl != 0 {
-		t.Errorf("Unexpected value for Qsdl, got %v", metrics[0].Qsdl)
+	if metrics[0].AvegareQueuedRequests != 0 {
+		t.Errorf("Unexpected value for AvegareQueuedRequests, got %v", metrics[0].AvegareQueuedRequests)
 	}
 }
 
@@ -191,13 +191,27 @@ func TestMmlsqosCollector(t *testing.T) {
 		return mmlsqosStdout, nil
 	}
 	expected := `
-# HELP gpfs_qos_et_seconds GPFS interval in seconds during which the measurement was made
-        # TYPE gpfs_qos_et_seconds gauge
-        gpfs_qos_et_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
-        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
-        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
-        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
-        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+		# HELP gpfs_qos_average_pending_requests GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS
+        # TYPE gpfs_qos_average_pending_requests gauge
+        gpfs_qos_average_pending_requests{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 5.579e-05
+        gpfs_qos_average_pending_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.013449
+        gpfs_qos_average_pending_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.7781e+08
+        gpfs_qos_average_pending_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.85256
+        gpfs_qos_average_pending_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 41.399
+        # HELP gpfs_qos_average_queued_requests GPFS average number of I/O requests in the class that are queued by QoS
+        # TYPE gpfs_qos_average_queued_requests gauge
+        gpfs_qos_average_queued_requests{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0
+        gpfs_qos_average_queued_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.0751e-05
+        gpfs_qos_average_queued_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.0055852
+        gpfs_qos_average_queued_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 7.734906573251e+07
+        gpfs_qos_average_queued_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.9398e+08
+        # HELP gpfs_qos_bs GPFS performance of the class in Bytes per second
+        # TYPE gpfs_qos_bs gauge
+        gpfs_qos_bs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 273.07016192
+        gpfs_qos_bs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.9020928e+06
+        gpfs_qos_bs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 2.232942592e+08
+        gpfs_qos_bs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.599602688e+09
+        gpfs_qos_bs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.5703474176e+08
         # HELP gpfs_qos_iops GPFS performance of the class in I/O operations per second
         # TYPE gpfs_qos_iops gauge
         gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.066667
@@ -205,27 +219,13 @@ func TestMmlsqosCollector(t *testing.T) {
         gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 24875
         gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 829.83
         gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 35545
-        # HELP gpfs_qos_ioql GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS
-        # TYPE gpfs_qos_ioql gauge
-        gpfs_qos_ioql{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 5.579e-05
-        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.013449
-        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.7781e+08
-        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.85256
-        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 41.399
-        # HELP gpfs_qos_mbs GPFS performance of the class in MegaBytes per second
-        # TYPE gpfs_qos_mbs gauge
-        gpfs_qos_mbs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.00026042
-        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.675
-        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 212.95
-        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1525.5
-        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 149.76
-        # HELP gpfs_qos_qsdl GPFS average number of I/O requests in the class that are queued by QoS
-        # TYPE gpfs_qos_qsdl gauge
-        gpfs_qos_qsdl{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0
-        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.0751e-05
-        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.0055852
-        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 7.734906573251e+07
-        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.9398e+08
+        # HELP gpfs_qos_measurement_interval_seconds GPFS interval in seconds during which the measurement was made
+        # TYPE gpfs_qos_measurement_interval_seconds gauge
+        gpfs_qos_measurement_interval_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+        gpfs_qos_measurement_interval_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
+        gpfs_qos_measurement_interval_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+        gpfs_qos_measurement_interval_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
+        gpfs_qos_measurement_interval_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
 	`
 	collector := NewMmlsqosCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -235,8 +235,9 @@ func TestMmlsqosCollector(t *testing.T) {
 		t.Errorf("Unexpected collection count %d, expected 28", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
-		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_et_seconds",
-		"gpfs_qos_iops", "gpfs_qos_ioql", "gpfs_qos_mbs", "gpfs_qos_qsdl"); err != nil {
+		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_measurement_interval_seconds",
+		"gpfs_qos_iops", "gpfs_qos_average_pending_requests", "gpfs_qos_bs",
+		 "gpfs_qos_average_queued_requests"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
@@ -256,13 +257,27 @@ func TestMmlsqosCollectorMmlsfs(t *testing.T) {
 		return mmlsfsStdout, nil
 	}
 	expected := `
-# HELP gpfs_qos_et_seconds GPFS interval in seconds during which the measurement was made
-        # TYPE gpfs_qos_et_seconds gauge
-        gpfs_qos_et_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
-        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
-        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
-        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
-        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+		# HELP gpfs_qos_average_pending_requests GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS
+        # TYPE gpfs_qos_average_pending_requests gauge
+        gpfs_qos_average_pending_requests{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 5.579e-05
+        gpfs_qos_average_pending_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.013449
+        gpfs_qos_average_pending_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.7781e+08
+        gpfs_qos_average_pending_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.85256
+        gpfs_qos_average_pending_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 41.399
+        # HELP gpfs_qos_average_queued_requests GPFS average number of I/O requests in the class that are queued by QoS
+        # TYPE gpfs_qos_average_queued_requests gauge
+        gpfs_qos_average_queued_requests{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0
+        gpfs_qos_average_queued_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.0751e-05
+        gpfs_qos_average_queued_requests{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.0055852
+        gpfs_qos_average_queued_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 7.734906573251e+07
+        gpfs_qos_average_queued_requests{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.9398e+08
+        # HELP gpfs_qos_bs GPFS performance of the class in Bytes per second
+        # TYPE gpfs_qos_bs gauge
+        gpfs_qos_bs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 273.07016192
+        gpfs_qos_bs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.9020928e+06
+        gpfs_qos_bs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 2.232942592e+08
+        gpfs_qos_bs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.599602688e+09
+        gpfs_qos_bs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.5703474176e+08
         # HELP gpfs_qos_iops GPFS performance of the class in I/O operations per second
         # TYPE gpfs_qos_iops gauge
         gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.066667
@@ -270,27 +285,13 @@ func TestMmlsqosCollectorMmlsfs(t *testing.T) {
         gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 24875
         gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 829.83
         gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 35545
-        # HELP gpfs_qos_ioql GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS
-        # TYPE gpfs_qos_ioql gauge
-        gpfs_qos_ioql{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 5.579e-05
-        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.013449
-        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.7781e+08
-        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 0.85256
-        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 41.399
-        # HELP gpfs_qos_mbs GPFS performance of the class in MegaBytes per second
-        # TYPE gpfs_qos_mbs gauge
-        gpfs_qos_mbs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.00026042
-        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 4.675
-        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 212.95
-        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1525.5
-        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 149.76
-        # HELP gpfs_qos_qsdl GPFS average number of I/O requests in the class that are queued by QoS
-        # TYPE gpfs_qos_qsdl gauge
-        gpfs_qos_qsdl{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0
-        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 1.0751e-05
-        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 0.0055852
-        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 7.734906573251e+07
-        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 1.9398e+08
+        # HELP gpfs_qos_measurement_interval_seconds GPFS interval in seconds during which the measurement was made
+        # TYPE gpfs_qos_measurement_interval_seconds gauge
+        gpfs_qos_measurement_interval_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+        gpfs_qos_measurement_interval_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
+        gpfs_qos_measurement_interval_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
+        gpfs_qos_measurement_interval_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="nvme1"} 30
+        gpfs_qos_measurement_interval_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680",pool="system"} 30
 	`
 	collector := NewMmlsqosCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)
@@ -300,8 +301,9 @@ func TestMmlsqosCollectorMmlsfs(t *testing.T) {
 		t.Errorf("Unexpected collection count %d, expected 28", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
-		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_et_seconds",
-		"gpfs_qos_iops", "gpfs_qos_ioql", "gpfs_qos_mbs", "gpfs_qos_qsdl"); err != nil {
+		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_measurement_interval_seconds",
+		"gpfs_qos_iops", "gpfs_qos_average_pending_requests", "gpfs_qos_bs",
+		 "gpfs_qos_average_queued_requests"); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }

--- a/collectors/mmlsqos_test.go
+++ b/collectors/mmlsqos_test.go
@@ -1,0 +1,411 @@
+// Copyright 2020 Trey Dockendorf
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	mmlsqosStdout = `
+mmlsqos:status:HEADER:version:reserved:reserved:enabled:throttling:monitoring:fineStatsSecs:idStats:
+mmlsqos:config:HEADER:version:reserved:reserved:config_enc:
+mmlsqos:values:HEADER:version:reserved:reserved:values_enc:
+mmlsqos:stats:HEADER:version:reserved:reserved:pool:timeEpoch:class:iops:ioql:qsdl:et:MBs:
+mmlsqos:status:0:1:::Yes:Yes:Yes:0:No:
+mmlsqos:config:0:1:::pool=sas1,other=inf,maintenance/all_local=50000Iops:
+mmlsqos:values:0:1:::pool=system,other=inf,maintenance/all_local=inf%3Apool=sas1,other=inf,maintenance/all_local=50000Iops%3Apool=sata1,other=inf,maintenance/all_local=inf%3Apool=sas2,other=inf,maintenance/all_local=inf%3Apool=nvme1,other=inf,maintenance/all_local=inf:
+mmlsqos:stats:0:1:::nvme1:1678438680:misc:33,267:0,013449:1,0751e-05:30:4.675:
+mmlsqos:stats:0:1:::nvme1:1678438680:other:829,83:0,85256:77349065,73251:30:1525.5:
+mmlsqos:stats:0:1:::system:1678438680:misc:24875:1,7781e+08:0,0055852:30:212.95:
+mmlsqos:stats:0:1:::system:1678438680:other:35545:41,399:1,9398e+08:30:149.76:
+mmlsqos:stats:0:1:::system:1678438680:maintenance:0,066667:5,579e-05:0,00000:30:0.00026042:
+`
+	mmlsqosStdoutNanValue = `
+mmlsqos:status:HEADER:version:reserved:reserved:enabled:throttling:monitoring:fineStatsSecs:idStats:
+mmlsqos:config:HEADER:version:reserved:reserved:config_enc:
+mmlsqos:values:HEADER:version:reserved:reserved:values_enc:
+mmlsqos:stats:HEADER:version:reserved:reserved:pool:timeEpoch:class:iops:ioql:qsdl:et:MBs:
+mmlsqos:status:0:1:::Yes:Yes:Yes:0:No:
+mmlsqos:config:0:1:::pool=sas1,other=inf,maintenance/all_local=50000Iops:
+mmlsqos:values:0:1:::pool=system,other=inf,maintenance/all_local=inf%3Apool=sas1,other=inf,maintenance/all_local=50000Iops%3Apool=sata1,other=inf,maintenance/all_local=inf%3Apool=sas2,other=inf,maintenance/all_local=inf%3Apool=nvme1,other=inf,maintenance/all_local=inf:
+mmlsqos:stats:0:1:::nvme1:1678438680:misc:33,267:0,013449:nan:30:4.675:
+mmlsqos:stats:0:1:::nvme1:1678438680:other:829,83:0,85256:0,00019576:30:1525.5:
+`
+	mmlsqosStdoutBadTime = `
+mmlsqos:status:HEADER:version:reserved:reserved:enabled:throttling:monitoring:fineStatsSecs:idStats:
+mmlsqos:config:HEADER:version:reserved:reserved:config_enc:
+mmlsqos:values:HEADER:version:reserved:reserved:values_enc:
+mmlsqos:stats:HEADER:version:reserved:reserved:pool:timeEpoch:class:iops:ioql:qsdl:et:MBs:
+mmlsqos:status:0:1:::Yes:Yes:Yes:0:No:
+mmlsqos:config:0:1:::pool=sas1,other=inf,maintenance/all_local=50000Iops:
+mmlsqos:values:0:1:::pool=system,other=inf,maintenance/all_local=inf%3Apool=sas1,other=inf,maintenance/all_local=50000Iops%3Apool=sata1,other=inf,maintenance/all_local=inf%3Apool=sas2,other=inf,maintenance/all_local=inf%3Apool=nvme1,other=inf,maintenance/all_local=inf:
+mmlsqos:stats:0:1:::nvme1:foo:misc:33,267:0,013449:1,0751e-05:30:4.675:
+mmlsqos:stats:0:1:::nvme1:1678438680:other:829,83:0,85256:0,00019576:30:1525.5:
+`
+	mmlsqosStdoutBadValue = `
+mmlsqos:status:HEADER:version:reserved:reserved:enabled:throttling:monitoring:fineStatsSecs:idStats:
+mmlsqos:config:HEADER:version:reserved:reserved:config_enc:
+mmlsqos:values:HEADER:version:reserved:reserved:values_enc:
+mmlsqos:stats:HEADER:version:reserved:reserved:pool:timeEpoch:class:iops:ioql:qsdl:et:MBs:
+mmlsqos:status:0:1:::Yes:Yes:Yes:0:No:
+mmlsqos:config:0:1:::pool=sas1,other=inf,maintenance/all_local=50000Iops:
+mmlsqos:values:0:1:::pool=system,other=inf,maintenance/all_local=inf%3Apool=sas1,other=inf,maintenance/all_local=50000Iops%3Apool=sata1,other=inf,maintenance/all_local=inf%3Apool=sas2,other=inf,maintenance/all_local=inf%3Apool=nvme1,other=inf,maintenance/all_local=inf:
+mmlsqos:stats:0:1:::nvme1:1678438680:misc:33,267:0,013449:foo:30:4.675:
+mmlsqos:stats:0:1:::nvme1:1678438680:other:829,83:0,85256:0,00019576:30:1525.5:
+`
+)
+
+func TestMmlsqos(t *testing.T) {
+	execCommand = fakeExecCommand
+	mockedExitStatus = 0
+	mockedStdout = "foo"
+	defer func() { execCommand = exec.CommandContext }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := mmlsqos("test", ctx)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	if out != mockedStdout {
+		t.Errorf("Unexpected out: %s", out)
+	}
+}
+
+func TestMmlsqosError(t *testing.T) {
+	execCommand = fakeExecCommand
+	mockedExitStatus = 1
+	mockedStdout = "foo"
+	defer func() { execCommand = exec.CommandContext }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := mmlsqos("test", ctx)
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+	if out != "" {
+		t.Errorf("Unexpected out: %s", out)
+	}
+}
+
+func TestMmlsqosTimeout(t *testing.T) {
+	execCommand = fakeExecCommand
+	mockedExitStatus = 1
+	mockedStdout = "foo"
+	defer func() { execCommand = exec.CommandContext }()
+	ctx, cancel := context.WithTimeout(context.Background(), 0*time.Second)
+	defer cancel()
+	out, err := mmlsqos("test", ctx)
+	if err != context.DeadlineExceeded {
+		t.Errorf("Expected DeadlineExceeded")
+	}
+	if out != "" {
+		t.Errorf("Unexpected out: %s", out)
+	}
+}
+
+func TestParseMmlsqos(t *testing.T) {
+	metrics, err := parse_mmlsqos(mmlsqosStdout, log.NewNopLogger())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+		return
+	}
+	if len(metrics) != 5 {
+		t.Errorf("Unexpected number of metrics, got %d", len(metrics))
+		return
+	}
+	if metrics[0].Pool != "nvme1" {
+		t.Errorf("Unexpected value for Pool, got %v", metrics[0].Pool)
+	}
+	if metrics[0].Time != 1678438680 {
+		t.Errorf("Unexpected value for Time, got %v", metrics[0].Time)
+	}
+	if metrics[0].Class != "misc" {
+		t.Errorf("Unexpected value for Class, got %v", metrics[0].Class)
+	}
+	if metrics[0].Iops != 33.267 {
+		t.Errorf("Unexpected value for Iops, got %v", metrics[0].Iops)
+	}
+	if metrics[0].Ioql != 0.013449 {
+		t.Errorf("Unexpected value for Ioql, got %v", metrics[0].Ioql)
+	}
+	if metrics[0].Qsdl != 1.0751e-05 {
+		t.Errorf("Unexpected value for Qsdl, got %v", metrics[0].Qsdl)
+	}
+	if metrics[0].ET != 30 {
+		t.Errorf("Unexpected value for ET, got %v", metrics[0].ET)
+	}
+	if metrics[0].MBs != 4.675 {
+		t.Errorf("Unexpected value for MBs, got %v", metrics[0].MBs)
+	}
+	metrics, err = parse_mmlsqos(mmlsqosStdoutNanValue, log.NewNopLogger())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+		return
+	}
+	if metrics[0].Qsdl != 0 {
+		t.Errorf("Unexpected value for Qsdl, got %v", metrics[0].Qsdl)
+	}
+}
+
+func TestParseMmlsqosErrors(t *testing.T) {
+	_, err := parse_mmlsqos(mmlsqosStdoutBadTime, log.NewNopLogger())
+	if err == nil {
+		t.Errorf("Expected error")
+		return
+	}
+	_, err = parse_mmlsqos(mmlsqosStdoutBadValue, log.NewNopLogger())
+	if err == nil {
+		t.Errorf("Expected error")
+		return
+	}
+}
+
+func TestMmlsqosCollector(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	filesystems := "mmfs1"
+	qosFilesystems = &filesystems
+	MmlsqosExec = func(fs string, ctx context.Context) (string, error) {
+		return mmlsqosStdout, nil
+	}
+	expected := `
+# HELP gpfs_qos_et_seconds GPFS interval in seconds during which the measurement was made
+        # TYPE gpfs_qos_et_seconds gauge
+        gpfs_qos_et_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
+        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 30
+        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
+        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 30
+        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
+        # HELP gpfs_qos_iops GPFS performance of the class in I/O operations per second
+        # TYPE gpfs_qos_iops gauge
+        gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.066667
+        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 33.267
+        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 24875
+        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 829.83
+        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 35545
+        # HELP gpfs_qos_ioql GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS
+        # TYPE gpfs_qos_ioql gauge
+        gpfs_qos_ioql{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 5.579e-05
+        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 0.013449
+        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 1.7781e+08
+        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 0.85256
+        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 41.399
+        # HELP gpfs_qos_mbs GPFS performance of the class in MegaBytes per second
+        # TYPE gpfs_qos_mbs gauge
+        gpfs_qos_mbs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.00026042
+        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 4.675
+        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 212.95
+        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 1525.5
+        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 149.76
+        # HELP gpfs_qos_qsdl GPFS average number of I/O requests in the class that are queued by QoS
+        # TYPE gpfs_qos_qsdl gauge
+        gpfs_qos_qsdl{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0
+        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 1.0751e-05
+        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.0055852
+        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 7.734906573251e+07
+        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 1.9398e+08
+	`
+	collector := NewMmlsqosCollector(log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if val, err := testutil.GatherAndCount(gatherers); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if val != 28 {
+		t.Errorf("Unexpected collection count %d, expected 28", val)
+	}
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
+		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_et_seconds",
+		"gpfs_qos_iops", "gpfs_qos_ioql", "gpfs_qos_mbs", "gpfs_qos_qsdl"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestMmlsqosCollectorMmlsfs(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	MmlsqosExec = func(fs string, ctx context.Context) (string, error) {
+		return mmlsqosStdout, nil
+	}
+	mmlsfsStdout = `
+		fs::HEADER:version:reserved:reserved:deviceName:fieldName:data:remarks:
+		mmlsfs::0:1:::mmfs1:defaultMountPoint:%2Ffs%mmfs1::
+	`
+	MmlsfsExec = func(ctx context.Context) (string, error) {
+		return mmlsfsStdout, nil
+	}
+	expected := `
+# HELP gpfs_qos_et_seconds GPFS interval in seconds during which the measurement was made
+        # TYPE gpfs_qos_et_seconds gauge
+        gpfs_qos_et_seconds{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
+        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 30
+        gpfs_qos_et_seconds{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
+        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 30
+        gpfs_qos_et_seconds{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 30
+        # HELP gpfs_qos_iops GPFS performance of the class in I/O operations per second
+        # TYPE gpfs_qos_iops gauge
+        gpfs_qos_iops{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.066667
+        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 33.267
+        gpfs_qos_iops{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 24875
+        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 829.83
+        gpfs_qos_iops{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 35545
+        # HELP gpfs_qos_ioql GPFS average number of I/O requests in the class that are pending for reasons other than being queued by QoS
+        # TYPE gpfs_qos_ioql gauge
+        gpfs_qos_ioql{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 5.579e-05
+        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 0.013449
+        gpfs_qos_ioql{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 1.7781e+08
+        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 0.85256
+        gpfs_qos_ioql{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 41.399
+        # HELP gpfs_qos_mbs GPFS performance of the class in MegaBytes per second
+        # TYPE gpfs_qos_mbs gauge
+        gpfs_qos_mbs{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.00026042
+        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 4.675
+        gpfs_qos_mbs{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 212.95
+        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 1525.5
+        gpfs_qos_mbs{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 149.76
+        # HELP gpfs_qos_qsdl GPFS average number of I/O requests in the class that are queued by QoS
+        # TYPE gpfs_qos_qsdl gauge
+        gpfs_qos_qsdl{class="maintenance",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0
+        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 1.0751e-05
+        gpfs_qos_qsdl{class="misc",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 0.0055852
+        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="nvme1"} 7.734906573251e+07
+        gpfs_qos_qsdl{class="other",fs="mmfs1",measurement_period_seconds="1678438680.00",pool="system"} 1.9398e+08
+	`
+	collector := NewMmlsqosCollector(log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if val, err := testutil.GatherAndCount(gatherers); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if val != 28 {
+		t.Errorf("Unexpected collection count %d, expected 28", val)
+	}
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
+		"gpfs_qos_epoch_timestamp_seconds", "gpfs_qos_et_seconds",
+		"gpfs_qos_iops", "gpfs_qos_ioql", "gpfs_qos_mbs", "gpfs_qos_qsdl"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestMmlsqosCollectorError(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	filesystems := "mmfs1"
+	configFilesystems = &filesystems
+	MmlsqosExec = func(fs string, ctx context.Context) (string, error) {
+		return "", fmt.Errorf("Error")
+	}
+	expected := `
+		# HELP gpfs_exporter_collect_error Indicates if error has occurred during collection
+		# TYPE gpfs_exporter_collect_error gauge
+		gpfs_exporter_collect_error{collector="mmlsqos-mmfs1"} 1
+	`
+	collector := NewMmlsqosCollector(log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if val, err := testutil.GatherAndCount(gatherers); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if val != 3 {
+		t.Errorf("Unexpected collection count %d, expected 3", val)
+	}
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected), "gpfs_exporter_collect_error"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestMmlsqosCollectorTimeout(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	filesystems := "mmfs1"
+	configFilesystems = &filesystems
+	MmlsqosExec = func(fs string, ctx context.Context) (string, error) {
+		return "", context.DeadlineExceeded
+	}
+	expected := `
+		# HELP gpfs_exporter_collect_timeout Indicates the collector timed out
+		# TYPE gpfs_exporter_collect_timeout gauge
+		gpfs_exporter_collect_timeout{collector="mmlsqos-mmfs1"} 1
+	`
+	collector := NewMmlsqosCollector(log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if val, err := testutil.GatherAndCount(gatherers); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if val != 3 {
+		t.Errorf("Unexpected collection count %d, expected 3", val)
+	}
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected), "gpfs_exporter_collect_timeout"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestMmlsqosCollectorMmlsfsError(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	filesystem := ""
+	qosFilesystems = &filesystem
+	MmlsfsExec = func(ctx context.Context) (string, error) {
+		return "", fmt.Errorf("Error")
+	}
+	expected := `
+		# HELP gpfs_exporter_collect_error Indicates if error has occurred during collection
+		# TYPE gpfs_exporter_collect_error gauge
+		gpfs_exporter_collect_error{collector="mmlsqos-mmlsfs"} 1
+	`
+	collector := NewMmlsqosCollector(log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if val, err := testutil.GatherAndCount(gatherers); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if val != 2 {
+		t.Errorf("Unexpected collection count %d, expected 2", val)
+	}
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected), "gpfs_exporter_collect_error"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestMmlsqosCollectorMmlsfsTimeout(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	filesystem := ""
+	qosFilesystems = &filesystem
+	MmlsfsExec = func(ctx context.Context) (string, error) {
+		return "", context.DeadlineExceeded
+	}
+	expected := `
+		# HELP gpfs_exporter_collect_timeout Indicates the collector timed out
+		# TYPE gpfs_exporter_collect_timeout gauge
+		gpfs_exporter_collect_timeout{collector="mmlsqos-mmlsfs"} 1
+	`
+	collector := NewMmlsqosCollector(log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if val, err := testutil.GatherAndCount(gatherers); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if val != 2 {
+		t.Errorf("Unexpected collection count %d, expected 2", val)
+	}
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected), "gpfs_exporter_collect_timeout"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}


### PR DESCRIPTION
Good day!
This library is really useful for generating GPFS metrics. However, we want to generate additional metrics from the output of `mmlsqos` command, which isn't included here. 
So, I've created this PR with my implementation to reach this goal.
P.S. I've already tested it in my dev environment and it works as expected.

