### PR TITLE
Add users and groups mmrepquota

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,0 @@
-{
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": []
-}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": []
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The default is FQDN of those running the exporter.
 ### mmrepquota
 
 * `--collector.mmrepquota.filesystems` - A comma separated list of filesystems to collect. Default is to collect all filesystems.
-* `--collector.mmrepquota.quotatypes` - Quota types to collect (`j` for FILESET, `u` for USR, `g` for GRP). Default is FILESET only. Ex: `uj` collects FILESET and USR.
+* `--collector.mmrepquota.quotatypes` - Comma seperated list of filesystem types to collect (`fileset` for FILESET, `user` for USR, `group` for GRP). Default is FILESET only. Ex: `fileset,user` collects FILESET and USR.
 
 ### mmlssnapshot
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The default is FQDN of those running the exporter.
 ### mmrepquota
 
 * `--collector.mmrepquota.filesystems` - A comma separated list of filesystems to collect. Default is to collect all filesystems.
-* `--collector.mmrepquota.quotatypes` - Comma seperated list of filesystem types to collect (`fileset` for FILESET, `user` for USR, `group` for GRP). Default is FILESET only. Ex: `fileset,user` collects FILESET and USR.
+* `--collector.mmrepquota.quota-types` - Comma seperated list of filesystem types to collect (`fileset` for FILESET, `user` for USR, `group` for GRP). Default is FILESET only. Ex: `fileset,user` collects FILESET and USR.
 
 ### mmlssnapshot
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The default is FQDN of those running the exporter.
 ### mmrepquota
 
 * `--collector.mmrepquota.filesystems` - A comma separated list of filesystems to collect. Default is to collect all filesystems.
+* `--collector.mmrepquota.quotatypes` - Quota types to collect (`j` for FILESET, `u` for USR, `g` for GRP). Default is FILESET only. Ex: `uj` collects FILESET and USR.
 
 ### mmlssnapshot
 

--- a/collectors/mmrepquota.go
+++ b/collectors/mmrepquota.go
@@ -45,6 +45,11 @@ var (
 		"filesLimit":     "FilesLimit",
 		"filesInDoubt":   "FilesInDoubt",
 	}
+	quotaTypeMap = map[string]rune{
+		"user":    'u',
+		"group":   'g',
+		"fileset": 'j',
+	}
 	mmrepquotaExec = mmrepquota
 )
 
@@ -193,8 +198,10 @@ func (c *MmrepquotaCollector) Collect(ch chan<- prometheus.Metric) {
 	errorMetric := 0
 	metrics := []QuotaMetric{}
 
-	for _, quotaType := range *configMmrepquotaTypes {
-		metric, err := c.collect(fmt.Sprintf("-%c", quotaType))
+	for _, quotaType := range strings.Split(*configMmrepquotaTypes, ",") {
+		quotaType = strings.TrimSpace(quotaType)
+		quotaArg := quotaTypeMap[quotaType]
+		metric, err := c.collect(fmt.Sprintf("-%c", quotaArg))
 		metrics = append(metrics, metric...)
 
 		if err == context.DeadlineExceeded {

--- a/collectors/mmrepquota.go
+++ b/collectors/mmrepquota.go
@@ -219,7 +219,7 @@ func (c *MmrepquotaCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	// merge metrics from results channel
-	for i := 0; i < len(typesToCollect); i++ {
+	for range typesToCollect {
 		result := <-results
 		metrics = append(metrics, result.Result...)
 

--- a/collectors/mmrepquota.go
+++ b/collectors/mmrepquota.go
@@ -16,6 +16,7 @@ package collectors
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -29,10 +30,12 @@ import (
 
 var (
 	configMmrepquotaFilesystems = kingpin.Flag("collector.mmrepquota.filesystems", "Filesystems to query with mmrepquota, comma separated. Defaults to all filesystems.").Default("").String()
+	configMmrepquotaTypes       = kingpin.Flag("collector.mmrepquota.quotatypes", "Quota Types to query with mmrepquota, Default to fileset only").Default("j").String()
 	mmrepquotaTimeout           = kingpin.Flag("collector.mmrepquota.timeout", "Timeout for mmrepquota execution").Default("20").Int()
 	quotaMap                    = map[string]string{
 		"name":           "Name",
 		"filesystemName": "FS",
+		"quotaType":      "QuotaType",
 		"blockUsage":     "BlockUsage",
 		"blockQuota":     "BlockQuota",
 		"blockLimit":     "BlockLimit",
@@ -48,6 +51,7 @@ var (
 type QuotaMetric struct {
 	Name         string
 	FS           string
+	QuotaType    string
 	BlockUsage   float64
 	BlockQuota   float64
 	BlockLimit   float64
@@ -59,15 +63,34 @@ type QuotaMetric struct {
 }
 
 type MmrepquotaCollector struct {
-	BlockUsage   *prometheus.Desc
-	BlockQuota   *prometheus.Desc
-	BlockLimit   *prometheus.Desc
-	BlockInDoubt *prometheus.Desc
-	FilesUsage   *prometheus.Desc
-	FilesQuota   *prometheus.Desc
-	FilesLimit   *prometheus.Desc
-	FilesInDoubt *prometheus.Desc
-	logger       log.Logger
+	FilesetBlockUsage   *prometheus.Desc
+	FilesetBlockQuota   *prometheus.Desc
+	FilesetBlockLimit   *prometheus.Desc
+	FilesetBlockInDoubt *prometheus.Desc
+	FilesetFilesUsage   *prometheus.Desc
+	FilesetFilesQuota   *prometheus.Desc
+	FilesetFilesLimit   *prometheus.Desc
+	FilesetFilesInDoubt *prometheus.Desc
+
+	UserBlockUsage   *prometheus.Desc
+	UserBlockQuota   *prometheus.Desc
+	UserBlockLimit   *prometheus.Desc
+	UserBlockInDoubt *prometheus.Desc
+	UserFilesUsage   *prometheus.Desc
+	UserFilesQuota   *prometheus.Desc
+	UserFilesLimit   *prometheus.Desc
+	UserFilesInDoubt *prometheus.Desc
+
+	GroupBlockUsage   *prometheus.Desc
+	GroupBlockQuota   *prometheus.Desc
+	GroupBlockLimit   *prometheus.Desc
+	GroupBlockInDoubt *prometheus.Desc
+	GroupFilesUsage   *prometheus.Desc
+	GroupFilesQuota   *prometheus.Desc
+	GroupFilesLimit   *prometheus.Desc
+	GroupFilesInDoubt *prometheus.Desc
+
+	logger log.Logger
 }
 
 func init() {
@@ -75,37 +98,92 @@ func init() {
 }
 
 func NewMmrepquotaCollector(logger log.Logger) Collector {
-	labels := []string{"fileset", "fs"}
+	fileset_labels := []string{"fileset", "fs"}
+	user_labels := []string{"user", "fs"}
+	group_labels := []string{"group", "fs"}
 	return &MmrepquotaCollector{
-		BlockUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "used_bytes"),
-			"GPFS fileset quota used", labels, nil),
-		BlockQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "quota_bytes"),
-			"GPFS fileset block quota", labels, nil),
-		BlockLimit: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "limit_bytes"),
-			"GPFS fileset quota block limit", labels, nil),
-		BlockInDoubt: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "in_doubt_bytes"),
-			"GPFS fileset quota block in doubt", labels, nil),
-		FilesUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "used_files"),
-			"GPFS fileset quota files used", labels, nil),
-		FilesQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "quota_files"),
-			"GPFS fileset files quota", labels, nil),
-		FilesLimit: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "limit_files"),
-			"GPFS fileset quota files limit", labels, nil),
-		FilesInDoubt: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "in_doubt_files"),
-			"GPFS fileset quota files in doubt", labels, nil),
+		FilesetBlockUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "used_bytes"),
+			"GPFS fileset quota used", fileset_labels, nil),
+		FilesetBlockQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "quota_bytes"),
+			"GPFS fileset block quota", fileset_labels, nil),
+		FilesetBlockLimit: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "limit_bytes"),
+			"GPFS fileset quota block limit", fileset_labels, nil),
+		FilesetBlockInDoubt: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "in_doubt_bytes"),
+			"GPFS fileset quota block in doubt", fileset_labels, nil),
+		FilesetFilesUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "used_files"),
+			"GPFS fileset quota files used", fileset_labels, nil),
+		FilesetFilesQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "quota_files"),
+			"GPFS fileset files quota", fileset_labels, nil),
+		FilesetFilesLimit: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "limit_files"),
+			"GPFS fileset quota files limit", fileset_labels, nil),
+		FilesetFilesInDoubt: prometheus.NewDesc(prometheus.BuildFQName(namespace, "fileset", "in_doubt_files"),
+			"GPFS fileset quota files in doubt", fileset_labels, nil),
+
+		UserBlockUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "user", "used_bytes"),
+			"GPFS user quota used", user_labels, nil),
+		UserBlockQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "user", "quota_bytes"),
+			"GPFS user block quota", user_labels, nil),
+		UserBlockLimit: prometheus.NewDesc(prometheus.BuildFQName(namespace, "user", "limit_bytes"),
+			"GPFS user quota block limit", user_labels, nil),
+		UserBlockInDoubt: prometheus.NewDesc(prometheus.BuildFQName(namespace, "user", "in_doubt_bytes"),
+			"GPFS user quota block in doubt", user_labels, nil),
+		UserFilesUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "user", "used_files"),
+			"GPFS user quota files used", user_labels, nil),
+		UserFilesQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "user", "quota_files"),
+			"GPFS user files quota", user_labels, nil),
+		UserFilesLimit: prometheus.NewDesc(prometheus.BuildFQName(namespace, "user", "limit_files"),
+			"GPFS user quota files limit", user_labels, nil),
+		UserFilesInDoubt: prometheus.NewDesc(prometheus.BuildFQName(namespace, "user", "in_doubt_files"),
+			"GPFS user quota files in doubt", user_labels, nil),
+
+		GroupBlockUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "group", "used_bytes"),
+			"GPFS group quota used", group_labels, nil),
+		GroupBlockQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "group", "quota_bytes"),
+			"GPFS group block quota", group_labels, nil),
+		GroupBlockLimit: prometheus.NewDesc(prometheus.BuildFQName(namespace, "group", "limit_bytes"),
+			"GPFS group quota block limit", group_labels, nil),
+		GroupBlockInDoubt: prometheus.NewDesc(prometheus.BuildFQName(namespace, "group", "in_doubt_bytes"),
+			"GPFS group quota block in doubt", group_labels, nil),
+		GroupFilesUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "group", "used_files"),
+			"GPFS group quota files used", group_labels, nil),
+		GroupFilesQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "group", "quota_files"),
+			"GPFS group files quota", group_labels, nil),
+		GroupFilesLimit: prometheus.NewDesc(prometheus.BuildFQName(namespace, "group", "limit_files"),
+			"GPFS group quota files limit", group_labels, nil),
+		GroupFilesInDoubt: prometheus.NewDesc(prometheus.BuildFQName(namespace, "group", "in_doubt_files"),
+			"GPFS group quota files in doubt", group_labels, nil),
+
 		logger: logger,
 	}
 }
 
 func (c *MmrepquotaCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.BlockUsage
-	ch <- c.BlockQuota
-	ch <- c.BlockLimit
-	ch <- c.BlockInDoubt
-	ch <- c.FilesUsage
-	ch <- c.FilesQuota
-	ch <- c.FilesLimit
-	ch <- c.FilesInDoubt
+	ch <- c.FilesetBlockUsage
+	ch <- c.FilesetBlockQuota
+	ch <- c.FilesetBlockLimit
+	ch <- c.FilesetBlockInDoubt
+	ch <- c.FilesetFilesUsage
+	ch <- c.FilesetFilesQuota
+	ch <- c.FilesetFilesLimit
+	ch <- c.FilesetFilesInDoubt
+
+	ch <- c.UserBlockUsage
+	ch <- c.UserBlockQuota
+	ch <- c.UserBlockLimit
+	ch <- c.UserBlockInDoubt
+	ch <- c.UserFilesUsage
+	ch <- c.UserFilesQuota
+	ch <- c.UserFilesLimit
+	ch <- c.UserFilesInDoubt
+
+	ch <- c.GroupBlockUsage
+	ch <- c.GroupBlockQuota
+	ch <- c.GroupBlockLimit
+	ch <- c.GroupBlockInDoubt
+	ch <- c.GroupFilesUsage
+	ch <- c.GroupFilesQuota
+	ch <- c.GroupFilesLimit
+	ch <- c.GroupFilesInDoubt
 }
 
 func (c *MmrepquotaCollector) Collect(ch chan<- prometheus.Metric) {
@@ -113,34 +191,60 @@ func (c *MmrepquotaCollector) Collect(ch chan<- prometheus.Metric) {
 	collectTime := time.Now()
 	timeout := 0
 	errorMetric := 0
-	metrics, err := c.collect()
-	if err == context.DeadlineExceeded {
-		timeout = 1
-		level.Error(c.logger).Log("msg", "Timeout executing mmrepquota")
-	} else if err != nil {
-		level.Error(c.logger).Log("msg", err)
-		errorMetric = 1
+	metrics := []QuotaMetric{}
+
+	for _, quotaType := range *configMmrepquotaTypes {
+		metric, err := c.collect(fmt.Sprintf("-%c", quotaType))
+		metrics = append(metrics, metric...)
+
+		if err == context.DeadlineExceeded {
+			timeout = 1
+			level.Error(c.logger).Log("msg", "Timeout executing mmrepquota")
+		} else if err != nil {
+			level.Error(c.logger).Log("msg", err)
+			errorMetric = 1
+		}
 	}
 
 	for _, m := range metrics {
-		ch <- prometheus.MustNewConstMetric(c.BlockUsage, prometheus.GaugeValue, m.BlockUsage, m.Name, m.FS)
-		ch <- prometheus.MustNewConstMetric(c.BlockQuota, prometheus.GaugeValue, m.BlockQuota, m.Name, m.FS)
-		ch <- prometheus.MustNewConstMetric(c.BlockLimit, prometheus.GaugeValue, m.BlockLimit, m.Name, m.FS)
-		ch <- prometheus.MustNewConstMetric(c.BlockInDoubt, prometheus.GaugeValue, m.BlockInDoubt, m.Name, m.FS)
-		ch <- prometheus.MustNewConstMetric(c.FilesUsage, prometheus.GaugeValue, m.FilesUsage, m.Name, m.FS)
-		ch <- prometheus.MustNewConstMetric(c.FilesQuota, prometheus.GaugeValue, m.FilesQuota, m.Name, m.FS)
-		ch <- prometheus.MustNewConstMetric(c.FilesLimit, prometheus.GaugeValue, m.FilesLimit, m.Name, m.FS)
-		ch <- prometheus.MustNewConstMetric(c.FilesInDoubt, prometheus.GaugeValue, m.FilesInDoubt, m.Name, m.FS)
+		if m.QuotaType == "FILESET" {
+			ch <- prometheus.MustNewConstMetric(c.FilesetBlockUsage, prometheus.GaugeValue, m.BlockUsage, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.FilesetBlockQuota, prometheus.GaugeValue, m.BlockQuota, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.FilesetBlockLimit, prometheus.GaugeValue, m.BlockLimit, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.FilesetBlockInDoubt, prometheus.GaugeValue, m.BlockInDoubt, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.FilesetFilesUsage, prometheus.GaugeValue, m.FilesUsage, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.FilesetFilesQuota, prometheus.GaugeValue, m.FilesQuota, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.FilesetFilesLimit, prometheus.GaugeValue, m.FilesLimit, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.FilesetFilesInDoubt, prometheus.GaugeValue, m.FilesInDoubt, m.Name, m.FS)
+		} else if m.QuotaType == "USR" {
+			ch <- prometheus.MustNewConstMetric(c.UserBlockUsage, prometheus.GaugeValue, m.BlockUsage, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.UserBlockQuota, prometheus.GaugeValue, m.BlockQuota, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.UserBlockLimit, prometheus.GaugeValue, m.BlockLimit, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.UserBlockInDoubt, prometheus.GaugeValue, m.BlockInDoubt, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.UserFilesUsage, prometheus.GaugeValue, m.FilesUsage, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.UserFilesQuota, prometheus.GaugeValue, m.FilesQuota, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.UserFilesLimit, prometheus.GaugeValue, m.FilesLimit, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.UserFilesInDoubt, prometheus.GaugeValue, m.FilesInDoubt, m.Name, m.FS)
+		} else if m.QuotaType == "GRP" {
+			ch <- prometheus.MustNewConstMetric(c.GroupBlockUsage, prometheus.GaugeValue, m.BlockUsage, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.GroupBlockQuota, prometheus.GaugeValue, m.BlockQuota, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.GroupBlockLimit, prometheus.GaugeValue, m.BlockLimit, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.GroupBlockInDoubt, prometheus.GaugeValue, m.BlockInDoubt, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.GroupFilesUsage, prometheus.GaugeValue, m.FilesUsage, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.GroupFilesQuota, prometheus.GaugeValue, m.FilesQuota, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.GroupFilesLimit, prometheus.GaugeValue, m.FilesLimit, m.Name, m.FS)
+			ch <- prometheus.MustNewConstMetric(c.GroupFilesInDoubt, prometheus.GaugeValue, m.FilesInDoubt, m.Name, m.FS)
+		}
 	}
 	ch <- prometheus.MustNewConstMetric(collectError, prometheus.GaugeValue, float64(errorMetric), "mmrepquota")
 	ch <- prometheus.MustNewConstMetric(collecTimeout, prometheus.GaugeValue, float64(timeout), "mmrepquota")
 	ch <- prometheus.MustNewConstMetric(collectDuration, prometheus.GaugeValue, time.Since(collectTime).Seconds(), "mmrepquota")
 }
 
-func (c *MmrepquotaCollector) collect() ([]QuotaMetric, error) {
+func (c *MmrepquotaCollector) collect(typeArg string) ([]QuotaMetric, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*mmrepquotaTimeout)*time.Second)
 	defer cancel()
-	out, err := mmrepquotaExec(ctx)
+	out, err := mmrepquotaExec(ctx, typeArg)
 	if err != nil {
 		return nil, err
 	}
@@ -148,13 +252,15 @@ func (c *MmrepquotaCollector) collect() ([]QuotaMetric, error) {
 	return metric, nil
 }
 
-func mmrepquota(ctx context.Context) (string, error) {
-	args := []string{"/usr/lpp/mmfs/bin/mmrepquota", "-j", "-Y"}
+func mmrepquota(ctx context.Context, typeArg string) (string, error) {
+	args := []string{"/usr/lpp/mmfs/bin/mmrepquota", typeArg, "-Y"}
+
 	if *configMmrepquotaFilesystems == "" {
 		args = append(args, "-a")
 	} else {
 		args = append(args, strings.Split(*configMmrepquotaFilesystems, ",")...)
 	}
+
 	cmd := execCommand(ctx, *sudoCmd, args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/collectors/mmrepquota.go
+++ b/collectors/mmrepquota.go
@@ -221,7 +221,6 @@ func (c *MmrepquotaCollector) Collect(ch chan<- prometheus.Metric) {
 	// merge metrics from results channel
 	for i := 0; i < len(typesToCollect); i++ {
 		result := <-results
-		fmt.Println(result)
 		metrics = append(metrics, result.Result...)
 
 		err := result.Error

--- a/collectors/mmrepquota.go
+++ b/collectors/mmrepquota.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	configMmrepquotaFilesystems = kingpin.Flag("collector.mmrepquota.filesystems", "Filesystems to query with mmrepquota, comma separated. Defaults to all filesystems.").Default("").String()
-	configMmrepquotaTypes       = kingpin.Flag("collector.mmrepquota.quotatypes", "Quota Types to query with mmrepquota, Default to fileset only").Default("fileset").String()
+	configMmrepquotaTypes       = kingpin.Flag("collector.mmrepquota.quota-types", "Quota Types to query with mmrepquota, Default to fileset only").Default("fileset").String()
 	mmrepquotaTimeout           = kingpin.Flag("collector.mmrepquota.timeout", "Timeout for mmrepquota execution").Default("20").Int()
 	quotaMap                    = map[string]string{
 		"name":           "Name",

--- a/collectors/mmrepquota.go
+++ b/collectors/mmrepquota.go
@@ -215,7 +215,6 @@ func (c *MmrepquotaCollector) Collect(ch chan<- prometheus.Metric) {
 		go func(quotaArg rune) {
 			metric, err := c.collect(fmt.Sprintf("-%c", quotaArg))
 			results <- MetricCollectionResult{Result: metric, Error: err}
-			fmt.Println(metric)
 		}(quotaArg)
 	}
 

--- a/collectors/mmrepquota_test.go
+++ b/collectors/mmrepquota_test.go
@@ -35,6 +35,16 @@ mmrepquota::0:1:::project:FILESET:408:PZS1003:341467872:2147483648:2147483648:0:
 *** Report for FILESET quotas on scratch
 mmrepquota::HEADER:version:reserved:reserved:filesystemName:quotaType:id:name:blockUsage:blockQuota:blockLimit:blockInDoubt:blockGrace:filesUsage:filesQuota:filesLimit:filesInDoubt:filesGrace:remarks:quota:defQuota:fid:filesetname:
 mmrepquota::0:1:::scratch:FILESET:0:root:928235294208:0:0:5308909920:none:141909093:0:0:140497:none:i:on:off:::
+`
+
+	mmrepquotaStdoutAll = `
+*** Report for FILESET quotas on project
+mmrepquota::HEADER:version:reserved:reserved:filesystemName:quotaType:id:name:blockUsage:blockQuota:blockLimit:blockInDoubt:blockGrace:filesUsage:filesQuota:filesLimit:filesInDoubt:filesGrace:remarks:quota:defQuota:fid:filesetname:
+mmrepquota::0:1:::project:FILESET:0:root:337419744:0:0:163840:none:1395:0:0:400:none:i:on:off:::
+mmrepquota::0:1:::project:FILESET:408:PZS1003:341467872:2147483648:2147483648:0:none:6286:2000000:2000000:0:none:e:on:off:::
+*** Report for FILESET quotas on scratch
+mmrepquota::HEADER:version:reserved:reserved:filesystemName:quotaType:id:name:blockUsage:blockQuota:blockLimit:blockInDoubt:blockGrace:filesUsage:filesQuota:filesLimit:filesInDoubt:filesGrace:remarks:quota:defQuota:fid:filesetname:
+mmrepquota::0:1:::scratch:FILESET:0:root:928235294208:0:0:5308909920:none:141909093:0:0:140497:none:i:on:off:::
 *** Report for USR quotas on home
 mmrepquota::HEADER:version:reserved:reserved:filesystemName:quotaType:id:name:blockUsage:blockQuota:blockLimit:blockInDoubt:blockGrace:filesUsage:filesQuota:filesLimit:filesInDoubt:filesGrace:remarks:quota:defQuota:fid:filesetname:
 mmrepquota::0:1:::home:USR:0:root:337419744:0:0:163840:none:1395:0:0:400:none:i:on:off:::
@@ -102,6 +112,25 @@ func TestMmrepquotaTimeout(t *testing.T) {
 
 func TestParseMmrepquota(t *testing.T) {
 	metrics := parse_mmrepquota(mmrepquotaStdout, log.NewNopLogger())
+	if len(metrics) != 3 {
+		t.Errorf("Unexpected metric count: %d", len(metrics))
+		return
+	}
+	if val := metrics[0].BlockUsage; val != 345517817856 {
+		t.Errorf("Unexpected BlockUsage got %v", val)
+	}
+	if val := metrics[0].BlockQuota; val != 0 {
+		t.Errorf("Unexpected BlockQuota got %v", val)
+	}
+	if val := metrics[0].BlockLimit; val != 0 {
+		t.Errorf("Unexpected BlockLimit got %v", val)
+	}
+	if val := metrics[0].BlockInDoubt; val != 167772160 {
+		t.Errorf("Unexpected BlockInDoubt got %v", val)
+	}
+}
+func TestParseMmrepquotaAll(t *testing.T) {
+	metrics := parse_mmrepquota(mmrepquotaStdoutAll, log.NewNopLogger())
 	if len(metrics) != 9 {
 		t.Errorf("Unexpected metric count: %d", len(metrics))
 		return
@@ -175,7 +204,81 @@ gpfs_fileset_used_bytes{fileset="root",fs="scratch"} 950512941268992
 gpfs_fileset_used_files{fileset="PZS1003",fs="project"} 6286
 gpfs_fileset_used_files{fileset="root",fs="project"} 1395
 gpfs_fileset_used_files{fileset="root",fs="scratch"} 141909093
+`
 
+	collector := NewMmrepquotaCollector(log.NewNopLogger())
+	gatherers := setupGatherer(collector)
+	if val, err := testutil.GatherAndCount(gatherers); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	} else if val != 27 {
+		t.Errorf("Unexpected collection count %d, expected 27", val)
+	}
+	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
+		"gpfs_exporter_collect_error", "gpfs_exporter_collect_timeout",
+
+		"gpfs_fileset_in_doubt_bytes", "gpfs_fileset_in_doubt_files",
+		"gpfs_fileset_limit_bytes", "gpfs_fileset_limit_files",
+		"gpfs_fileset_quota_bytes", "gpfs_fileset_quota_files",
+		"gpfs_fileset_used_bytes", "gpfs_fileset_used_files"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestMmrepquotaCollectorAll(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	mmrepquotaExec = func(ctx context.Context, typeArg string) (string, error) {
+		return mmrepquotaStdoutAll, nil
+	}
+	expected := `
+# HELP gpfs_exporter_collect_error Indicates if error has occurred during collection
+# TYPE gpfs_exporter_collect_error gauge
+gpfs_exporter_collect_error{collector="mmrepquota"} 0
+# HELP gpfs_exporter_collect_timeout Indicates the collector timed out
+# TYPE gpfs_exporter_collect_timeout gauge
+gpfs_exporter_collect_timeout{collector="mmrepquota"} 0
+
+# HELP gpfs_fileset_in_doubt_bytes GPFS fileset quota block in doubt
+# TYPE gpfs_fileset_in_doubt_bytes gauge
+gpfs_fileset_in_doubt_bytes{fileset="PZS1003",fs="project"} 0
+gpfs_fileset_in_doubt_bytes{fileset="root",fs="project"} 167772160
+gpfs_fileset_in_doubt_bytes{fileset="root",fs="scratch"} 5436323758080
+# HELP gpfs_fileset_in_doubt_files GPFS fileset quota files in doubt
+# TYPE gpfs_fileset_in_doubt_files gauge
+gpfs_fileset_in_doubt_files{fileset="PZS1003",fs="project"} 0
+gpfs_fileset_in_doubt_files{fileset="root",fs="project"} 400
+gpfs_fileset_in_doubt_files{fileset="root",fs="scratch"} 140497
+# HELP gpfs_fileset_limit_bytes GPFS fileset quota block limit
+# TYPE gpfs_fileset_limit_bytes gauge
+gpfs_fileset_limit_bytes{fileset="PZS1003",fs="project"} 2199023255552
+gpfs_fileset_limit_bytes{fileset="root",fs="project"} 0
+gpfs_fileset_limit_bytes{fileset="root",fs="scratch"} 0
+# HELP gpfs_fileset_limit_files GPFS fileset quota files limit
+# TYPE gpfs_fileset_limit_files gauge
+gpfs_fileset_limit_files{fileset="PZS1003",fs="project"} 2000000
+gpfs_fileset_limit_files{fileset="root",fs="project"} 0
+gpfs_fileset_limit_files{fileset="root",fs="scratch"} 0
+# HELP gpfs_fileset_quota_bytes GPFS fileset block quota
+# TYPE gpfs_fileset_quota_bytes gauge
+gpfs_fileset_quota_bytes{fileset="PZS1003",fs="project"} 2199023255552
+gpfs_fileset_quota_bytes{fileset="root",fs="project"} 0
+gpfs_fileset_quota_bytes{fileset="root",fs="scratch"} 0
+# HELP gpfs_fileset_quota_files GPFS fileset files quota
+# TYPE gpfs_fileset_quota_files gauge
+gpfs_fileset_quota_files{fileset="PZS1003",fs="project"} 2000000
+gpfs_fileset_quota_files{fileset="root",fs="project"} 0
+gpfs_fileset_quota_files{fileset="root",fs="scratch"} 0
+# HELP gpfs_fileset_used_bytes GPFS fileset quota used
+# TYPE gpfs_fileset_used_bytes gauge
+gpfs_fileset_used_bytes{fileset="PZS1003",fs="project"} 349663100928
+gpfs_fileset_used_bytes{fileset="root",fs="project"} 345517817856
+gpfs_fileset_used_bytes{fileset="root",fs="scratch"} 950512941268992
+# HELP gpfs_fileset_used_files GPFS fileset quota files used
+# TYPE gpfs_fileset_used_files gauge
+gpfs_fileset_used_files{fileset="PZS1003",fs="project"} 6286
+gpfs_fileset_used_files{fileset="root",fs="project"} 1395
+gpfs_fileset_used_files{fileset="root",fs="scratch"} 141909093
 # HELP gpfs_user_in_doubt_bytes GPFS user quota block in doubt
 # TYPE gpfs_user_in_doubt_bytes gauge
 gpfs_user_in_doubt_bytes{fs="home",user="PZS1003"} 0
@@ -257,13 +360,14 @@ gpfs_group_used_bytes{fs="scratch",group="root"} 950512941268992
 gpfs_group_used_files{fs="project",group="PZS1003"} 6286
 gpfs_group_used_files{fs="project",group="root"} 1395
 gpfs_group_used_files{fs="scratch",group="root"} 141909093
-	`
+`
+
 	collector := NewMmrepquotaCollector(log.NewNopLogger())
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	} else if val != 75 {
-		t.Errorf("Unexpected collection count %d, expected 27", val)
+		t.Errorf("Unexpected collection count %d, expected 75", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"gpfs_exporter_collect_error", "gpfs_exporter_collect_timeout",


### PR DESCRIPTION
Hi, I've implemented user and group quotas in mmrepquota. This would resolve issue #49.

I've added the extra quotas as separate Prometheus metrics to preserve backwards compatibility, the existing FILESET quotas are unchanged. User and group quotas are disabled by default and can be enabled by a flag (`--collector.mmrepquota.quotatypes`)